### PR TITLE
0.6.1: peek/read correctness across sync, futures, and tokio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Run tarpaulin
         env:
           RUSTFLAGS: "--cfg tarpaulin"
-        run: cargo tarpaulin --all-features --run-types lib --run-types tests --run-types doctests --workspace --out xml
+        run: cargo tarpaulin --all-features --engine llvm --run-types lib --run-types tests --run-types doctests --workspace --out xml
       - name: Upload coverage report artifact
         # Lets us download the exact cobertura.xml the CI produced and
         # diff it locally against a local tarpaulin run — useful when

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 
 /target
 Cargo.lock
+
+# Tarpaulin coverage output
+cobertura.xml
+tarpaulin-report.html
+lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## UNRELEASED
 
+### 0.6.1
+
+#### Fixed (correctness)
+
+- **`peek_to_string` (sync / `future` / `tokio`)** — on an ordinary
+  I/O error, the caller's `String` now receives the longest
+  valid-UTF-8 prefix of the bytes consumed so far, matching
+  `std::io::Read::read_to_string`. In 0.6.0 any I/O error left the
+  caller's `String` unchanged, hiding partial text the reader had
+  already produced. When the consumed bytes are not valid UTF-8
+  (e.g. the reader errored mid multi-byte sequence) the `String`
+  is still left unchanged. Clean `InvalidData` behavior on an
+  entirely invalid stream is unaffected.
+
+- **Fallible `Buffer` implementations can no longer desync the inner
+  reader from the peek buffer.** Every peek path (sync, futures,
+  tokio × `peek` / `peek_exact` / `peek_to_end` / `peek_to_string`)
+  now grows the peek buffer first and has the reader write
+  directly into the resized tail, truncating to the actual `n` on
+  both success and error. A `Buffer` that returns `Err` from
+  `resize` / `extend_from_slice` now fails before the reader
+  advances, so replay via a later `peek` / `read` remains correct.
+
+#### Internal
+
+- Removed the fixed-size `StagingBuf` staging helper used by the
+  async futures; the peek buffer itself is now the staging area,
+  so no separate per-future allocation is needed.
+
 ### 0.6.0
 
 #### Fixed (correctness — async futures + tokio)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peekable"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 repository = "https://github.com/al8n/peekable"
 homepage = "https://github.com/al8n/peekable"

--- a/docs/superpowers/plans/2026-04-24-peek-buffer-correctness.md
+++ b/docs/superpowers/plans/2026-04-24-peek-buffer-correctness.md
@@ -1,0 +1,746 @@
+# Peek Buffer Correctness Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two correctness regressions in `Peekable` / `AsyncPeekable`:
+1. `peek_to_string` discards partial valid UTF-8 on ordinary I/O errors, diverging from `std::io::Read::read_to_string`.
+2. Several paths first consume bytes from the inner reader, then mirror them into the peek buffer via `Buffer::extend_from_slice`; if the fallible mirror fails, the reader has advanced but the peek buffer has not, breaking replay.
+
+**Architecture:** Unify every "consume-then-mirror" code path onto a single pattern: **grow the peek buffer first, read directly into its tail, then truncate to the actual `n` on both success and error.** This makes the peek buffer the single source of truth for what the reader has produced, and naturally permits partial-data semantics. `peek_to_string` additionally checks UTF-8 validity of the full peek buffer and pushes the valid prefix to the caller's `String` on I/O error.
+
+**Tech Stack:** Rust sync (`std::io::Read`), futures (`futures_util::AsyncRead`), tokio (`tokio::io::AsyncRead` + `ReadBuf`). Uses `Buffer` trait with fallible `resize` / `extend_from_slice`.
+
+---
+
+## File Structure
+
+- `src/lib.rs` — sync `Peekable::peek` / `peek_exact` / `peek_to_end` / `peek_to_string` (+ existing unit tests at bottom).
+- `src/future.rs` — `AsyncPeekable::poll_peek`.
+- `src/future/peek_exact.rs`, `peek_to_end.rs`, `peek_to_string.rs` — async future state machines.
+- `src/tokio.rs` — tokio `AsyncPeekable::poll_peek`.
+- `src/tokio/peek_exact.rs`, `peek_to_end.rs`, `peek_to_string.rs` — tokio future state machines.
+- `tests/sync.rs`, `tests/futures_io.rs`, `tests/tokio_io.rs` — append regression tests.
+- `Cargo.toml` — version bump 0.6.0 → 0.6.1.
+- `CHANGELOG.md` — describe fixes.
+
+### Test support types (introduce once, reuse)
+
+Both test helpers go at the top of each tests file (or a shared `tests/common/mod.rs`). Scope: used by new tests in this plan; keep `#[allow(dead_code)]` per helper if not used by every tests file.
+
+```rust
+// A Buffer whose extend_from_slice / resize fail once CAP bytes are
+// exceeded. CAP is a const generic so tests pick a cap per scenario
+// (the crate's constructor API calls Buffer::new() with no runtime
+// argument, so a runtime cap field wouldn't plumb through).
+#[derive(Debug, Default)]
+pub struct BoundedBuffer<const CAP: usize> { inner: Vec<u8> }
+
+impl<const CAP: usize> peekable::Buffer for BoundedBuffer<CAP> {
+    fn new() -> Self { Self { inner: Vec::new() } }
+    fn with_capacity(_: usize) -> Self { Self { inner: Vec::new() } }
+    fn consume(&mut self, rng: std::ops::RangeTo<usize>) { self.inner.drain(rng); }
+    fn clear(&mut self) { self.inner.clear(); }
+    fn resize(&mut self, len: usize) -> std::io::Result<()> {
+        if len > CAP {
+            return Err(std::io::Error::new(std::io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+        }
+        self.inner.resize(len, 0); Ok(())
+    }
+    fn truncate(&mut self, len: usize) { self.inner.truncate(len); }
+    fn extend_from_slice(&mut self, other: &[u8]) -> std::io::Result<()> {
+        if self.inner.len() + other.len() > CAP {
+            return Err(std::io::Error::new(std::io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+        }
+        self.inner.extend_from_slice(other); Ok(())
+    }
+    fn as_slice(&self) -> &[u8] { &self.inner }
+    fn as_mut_slice(&mut self) -> &mut [u8] { &mut self.inner }
+    fn len(&self) -> usize { self.inner.len() }
+    fn is_empty(&self) -> bool { self.inner.is_empty() }
+    fn capacity(&self) -> usize { CAP }
+}
+
+// Reader that hands out a fixed payload, then returns a custom io::Error.
+#[derive(Debug)]
+pub struct ErroringReader {
+    data: std::io::Cursor<Vec<u8>>,
+    pub error_after: usize, // total bytes to serve before erroring
+    served: usize,
+    pub kind: std::io::ErrorKind,
+}
+
+impl ErroringReader {
+    pub fn new(data: Vec<u8>, error_after: usize, kind: std::io::ErrorKind) -> Self {
+        Self { data: std::io::Cursor::new(data), error_after, served: 0, kind }
+    }
+}
+
+impl std::io::Read for ErroringReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.served >= self.error_after {
+            return Err(std::io::Error::new(self.kind, "synthetic"));
+        }
+        let cap = (self.error_after - self.served).min(buf.len());
+        let n = std::io::Read::read(&mut self.data, &mut buf[..cap])?;
+        self.served += n; Ok(n)
+    }
+}
+
+// Async version uses futures_util::io::AsyncRead / tokio::io::AsyncRead
+// — see the per-target tests file for wrappers.
+```
+
+---
+
+## Canonical refactor shapes
+
+These are the only two patterns every task applies.
+
+### Pattern A — bounded read (for `peek`, `peek_exact`)
+
+Given a desired extra byte count `want`:
+
+```text
+old_len = buffer.len();
+buffer.resize(old_len + want)?;                      // fails cleanly if Buffer can't grow
+match reader.read(&mut buffer.as_mut_slice()[old_len..]) {
+    Ok(n)  => { buffer.truncate(old_len + n);         // n may be < want (short read)
+                /* copy buffer[old_len..old_len+n] to caller slice */ }
+    Err(e) => { buffer.truncate(old_len); return Err(e); }
+}
+```
+
+For Interrupted retry: loop around the `reader.read` call (truncate + continue).
+
+### Pattern B — unbounded chunked read (for `peek_to_end`, `peek_to_string`)
+
+```text
+let inbuf = buffer.len();
+loop {
+    let old_len = buffer.len();
+    buffer.resize(old_len + CHUNK)?;
+    match reader.read(&mut buffer.as_mut_slice()[old_len..]) {
+        Ok(0)  => { buffer.truncate(old_len); break Ok(()); }
+        Ok(n)  => { buffer.truncate(old_len + n); }
+        Err(e) if e.kind() == Interrupted => { buffer.truncate(old_len); continue; }
+        Err(e) => { buffer.truncate(old_len); break Err(e); }
+    }
+}
+```
+
+`CHUNK`: reuse existing `STAGING_CAP` = 1024 for async; for sync, define `const READ_CHUNK: usize = 1024;` near the top of `lib.rs`.
+
+`peek_to_end` then copies `buffer.as_slice()[inbuf..]` into the caller's `Vec` at the end (or the existing peek-prefix + reader-data layout that the current code already uses). On `break Err(e)`, still copy whatever was accumulated in `buffer[inbuf..]` to caller `buf` (partial-data-on-error contract), then return the error.
+
+`peek_to_string` at end:
+```text
+let validated = core::str::from_utf8(buffer.as_slice());
+match (loop_result, validated) {
+    (Ok(()), Ok(s))   => { caller_buf.push_str(s); Ok(buffer.len()) }
+    (Ok(()), Err(e))  => Err(invalid_utf8_io_error(e)),           // caller_buf unchanged
+    (Err(io), Ok(s))  => { caller_buf.push_str(s); Err(io) }       // partial-UTF-8 preserve
+    (Err(io), Err(_)) => Err(io),                                   // caller_buf unchanged
+}
+```
+
+Note: the existing peek-buffer prefix must still be validated up front (allowing incomplete trailing multi-byte sequences — same as current code).
+
+---
+
+## Task 1 — Plan-only prep
+
+- [ ] **Step 1: Create a feature branch.**
+  ```bash
+  git checkout -b fix/peek-buffer-correctness
+  ```
+
+- [ ] **Step 2: Add `READ_CHUNK` constant and the two test-helper types.**
+
+  In `src/lib.rs`, near the other internal consts:
+  ```rust
+  /// Chunk size used by sync `peek_to_end` / `peek_to_string`.
+  const READ_CHUNK: usize = 1024;
+  ```
+
+  In `tests/sync.rs`, append `BoundedBuffer` and `ErroringReader` from the File Structure section above. (Do **not** add async wrappers yet — those come in Tasks 6, 8.)
+
+- [ ] **Step 3: Commit.**
+  ```bash
+  git add -A && git commit -m "test(sync): add BoundedBuffer and ErroringReader helpers"
+  ```
+
+---
+
+## Task 2 — Sync `peek` (Finding 2)
+
+**File:** `src/lib.rs:548-606`
+
+- [ ] **Step 1: Write regression test in `tests/sync.rs`.**
+
+  ```rust
+  #[test]
+  fn peek_does_not_advance_reader_when_buffer_extend_fails() {
+      use peekable::PeekExt;
+      // Cap is 0 so even the first resize fails.
+      let reader = std::io::Cursor::new(vec![1u8, 2, 3, 4]);
+      let mut p = reader.peekable_with_buffer::<BoundedBuffer<0>>();
+      let mut buf = [0u8; 2];
+      let err = p.peek(&mut buf).expect_err("must fail");
+      assert_eq!(err.kind(), std::io::ErrorKind::OutOfMemory);
+      // Reader must not have advanced past what the peek buffer can
+      // replay. Follow-up read should see all four bytes.
+      let mut out = Vec::new();
+      let (_, reader) = p.get_mut();
+      std::io::Read::read_to_end(reader, &mut out).unwrap();
+      assert_eq!(out, [1, 2, 3, 4]);
+  }
+  ```
+
+  Note: `p.get_mut()` returns `(&[u8], &mut R)` per `src/lib.rs:382` — destructure to reach the inner reader.
+
+- [ ] **Step 2: Run and confirm it fails.**
+  ```bash
+  cargo test --test sync peek_does_not_advance_reader_when_buffer_extend_fails -- --nocapture
+  ```
+  Expected: panic / assertion failure — today the reader advances past what the buffer can replay.
+
+- [ ] **Step 3: Rewrite sync `peek` to use Pattern A.**
+
+  Replace lib.rs:548-606 body. The three buffer-already-satisfies branches (Less / Equal) remain unchanged. The Greater branch already uses Pattern A — verify it still does after the rewrite and that `truncate(buffer_len)` happens on every `Err` path.
+
+  For the final "no peek-buffer contents" branch (lib.rs:595-605):
+
+  ```rust
+  let this = self;
+  let want = buf.len();
+  if want == 0 {
+      return Ok(0);
+  }
+  let old_len = this.buffer.len();        // == 0 on this path, but keep for symmetry
+  this.buffer.resize(old_len + want)?;
+  loop {
+      match this.reader.read(&mut this.buffer.as_mut_slice()[old_len..]) {
+          Ok(n) => {
+              this.buffer.truncate(old_len + n);
+              buf[..n].copy_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+              return Ok(n);
+          }
+          Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+          Err(e) => {
+              this.buffer.truncate(old_len);
+              return Err(e);
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 4: Confirm test passes + full sync suite still passes.**
+  ```bash
+  cargo test --test sync
+  ```
+
+- [ ] **Step 5: Commit.**
+  ```bash
+  git commit -am "fix(sync): read directly into peek buffer in peek() to preserve replay on Buffer error"
+  ```
+
+---
+
+## Task 3 — Sync `peek_exact` (Finding 2)
+
+**File:** `src/lib.rs:882-919`
+
+- [ ] **Step 1: Write regression test.**
+
+  ```rust
+  #[test]
+  fn peek_exact_does_not_advance_reader_when_buffer_extend_fails() {
+      use peekable::PeekExt;
+      let reader = std::io::Cursor::new(vec![1u8, 2, 3, 4]);
+      // Cap 0 → first resize(+4) fails immediately.
+      let mut p = reader.peekable_with_buffer::<BoundedBuffer<0>>();
+      let mut buf = [0u8; 4];
+      let err = p.peek_exact(&mut buf).expect_err("must fail");
+      assert_eq!(err.kind(), std::io::ErrorKind::OutOfMemory);
+      // Peek buffer contents + remaining reader bytes must == 4.
+      let (peek_slice, reader) = p.get_mut();
+      let have = peek_slice.len();
+      let mut out = Vec::new();
+      std::io::Read::read_to_end(reader, &mut out).unwrap();
+      assert_eq!(have + out.len(), 4);
+  }
+  ```
+
+  The invariant is `peek_buffer.len() + reader_remaining == 4`. `get_mut()` returns both simultaneously.
+
+- [ ] **Step 2: Run and confirm failure.**
+  ```bash
+  cargo test --test sync peek_exact_does_not_advance_reader_when_buffer_extend_fails
+  ```
+
+- [ ] **Step 3: Rewrite the inner read loop using Pattern A.**
+
+  Current body reads into caller `buf` then mirrors. Replace with: extend peek buffer by `remaining` bytes, read into its tail, truncate, then copy the bytes from the peek buffer into the caller's slice.
+
+  ```rust
+  pub fn peek_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+      let this = self;
+      let total = buf.len();
+      let peek_buf_len = this.buffer.len();
+
+      if total <= peek_buf_len {
+          buf.copy_from_slice(&this.buffer.as_slice()[..total]);
+          return Ok(());
+      }
+
+      // Copy prefix from existing peek buffer.
+      buf[..peek_buf_len].copy_from_slice(this.buffer.as_slice());
+      let mut filled = peek_buf_len;
+
+      while filled < total {
+          let old_len = this.buffer.len();
+          let want = total - filled;
+          this.buffer.resize(old_len + want)?;
+
+          let n = loop {
+              match this.reader.read(&mut this.buffer.as_mut_slice()[old_len..]) {
+                  Ok(n) => break n,
+                  Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                  Err(e) => {
+                      this.buffer.truncate(old_len);
+                      return Err(e);
+                  }
+              }
+          };
+          this.buffer.truncate(old_len + n);
+          if n == 0 {
+              return Err(std::io::ErrorKind::UnexpectedEof.into());
+          }
+          buf[filled..filled + n]
+              .copy_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+          filled += n;
+      }
+      Ok(())
+  }
+  ```
+
+  Note: removes the `mem::take(&mut buf).split_at_mut(...)` dance — cleaner and no more `mem` import needed *if* nothing else uses it. Check lib.rs imports before removing.
+
+- [ ] **Step 4: Run all sync tests.**
+  ```bash
+  cargo test --test sync
+  cargo test --lib
+  ```
+
+- [ ] **Step 5: Commit.**
+  ```bash
+  git commit -am "fix(sync): read directly into peek buffer in peek_exact() to preserve replay on Buffer error"
+  ```
+
+---
+
+## Task 4 — Sync `peek_to_end` (Finding 2, partial-data contract)
+
+**File:** `src/lib.rs:675-703`
+
+- [ ] **Step 1: Write regression tests.**
+
+  ```rust
+  #[test]
+  fn peek_to_end_preserves_partial_data_on_io_error() {
+      let reader = ErroringReader::new(b"hello".to_vec(), 3, std::io::ErrorKind::ConnectionReset);
+      let mut p = peekable::PeekExt::peekable(reader);
+      let mut out = Vec::new();
+      let err = p.peek_to_end(&mut out).expect_err("io error expected");
+      assert_eq!(err.kind(), std::io::ErrorKind::ConnectionReset);
+      assert_eq!(out, b"hel");
+  }
+
+  #[test]
+  fn peek_to_end_does_not_desync_on_buffer_error() {
+      use peekable::PeekExt;
+      let reader = std::io::Cursor::new(b"abcdef".to_vec());
+      // Cap 2: first resize to old_len (0) + READ_CHUNK fails.
+      // We pre-fill the peek buffer to 2 bytes first so resize target
+      // becomes 2 + READ_CHUNK > 2 and fails on the peek_to_end chunk.
+      let mut p = reader.peekable_with_buffer::<BoundedBuffer<2>>();
+      let mut scratch = [0u8; 2];
+      assert_eq!(p.peek(&mut scratch).unwrap(), 2);
+      let mut out = Vec::new();
+      let err = p.peek_to_end(&mut out).expect_err("must fail");
+      assert_eq!(err.kind(), std::io::ErrorKind::OutOfMemory);
+      // Invariant: peek buffer length + what reader still has == 6.
+      let (peek_slice, reader) = p.get_mut();
+      let have = peek_slice.len();
+      let mut tail = Vec::new();
+      std::io::Read::read_to_end(reader, &mut tail).unwrap();
+      assert_eq!(have + tail.len(), 6);
+  }
+  ```
+
+- [ ] **Step 2: Rewrite `peek_to_end` using Pattern B.**
+
+  ```rust
+  pub fn peek_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+      let this = &mut *self;
+      let inbuf = this.buffer.len();
+      let caller_start = buf.len();
+
+      // Copy existing peek-buffer prefix into caller's buf up front.
+      buf.extend_from_slice(this.buffer.as_slice());
+
+      loop {
+          let old_len = this.buffer.len();
+          this.buffer.resize(old_len + READ_CHUNK)?;
+          let n = match this.reader.read(&mut this.buffer.as_mut_slice()[old_len..]) {
+              Ok(n) => n,
+              Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                  this.buffer.truncate(old_len);
+                  continue;
+              }
+              Err(e) => {
+                  this.buffer.truncate(old_len);
+                  // Preserve partial data in caller's buf: anything we
+                  // mirrored into the peek buffer since this call began
+                  // (i.e. buffer[inbuf..]) minus what we already copied
+                  // (caller_start+inbuf up to caller_start+current len).
+                  let already_in_caller = buf.len() - caller_start;
+                  buf.extend_from_slice(&this.buffer.as_slice()[inbuf + (already_in_caller - inbuf)..]);
+                  return Err(e);
+              }
+          };
+          this.buffer.truncate(old_len + n);
+          if n == 0 {
+              return Ok(this.buffer.len()); // total length of accumulated content
+          }
+          buf.extend_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+      }
+  }
+  ```
+
+  Wait — simplify. Because we copy chunks into `buf` as we mirror them, on Err we don't need any catch-up copy; `buf` already has everything we've successfully mirrored. The Err arm becomes:
+
+  ```rust
+          Err(e) => {
+              this.buffer.truncate(old_len);
+              return Err(e);
+          }
+  ```
+
+  And the loop body only extends `buf` from the successful `n`-byte chunk. Use this simpler form in the implementation.
+
+- [ ] **Step 3: Check return value.** Current signature returns `Result<usize>` — the count of "bytes peek". Existing code returns `read + inbuf` where `read` = count returned by `read_to_end`. Match that: return `this.buffer.len()` minus the value of `inbuf` at entry? No — current returns `read + inbuf`. `read` is the bytes the inner reader produced, `inbuf` is the pre-existing peek buffer length. After our loop, `this.buffer.len() == inbuf + (bytes read)`, so return that. But existing semantics is `read + inbuf` which equals `this.buffer.len() - 0` (since peek buffer started at `inbuf`). Same thing. Use `Ok(this.buffer.len())` after the `n == 0` branch only if `inbuf` was included; otherwise adjust.
+
+  Safer: track `read_total` independently by accumulating `n`s, then return `read_total + inbuf` to exactly match the old semantics.
+
+- [ ] **Step 4: Run tests.**
+  ```bash
+  cargo test --test sync peek_to_end
+  cargo test --lib
+  ```
+
+- [ ] **Step 5: Commit.**
+  ```bash
+  git commit -am "fix(sync): chunked read-into-peek-buffer for peek_to_end; mirror bytes before yielding to caller"
+  ```
+
+---
+
+## Task 5 — Sync `peek_to_string` (Findings 1 + 2)
+
+**File:** `src/lib.rs:751-794`
+
+- [ ] **Step 1: Write regression tests.**
+
+  ```rust
+  #[test]
+  fn peek_to_string_preserves_partial_valid_utf8_on_io_error() {
+      let reader = ErroringReader::new(b"hello".to_vec(), 3, std::io::ErrorKind::ConnectionReset);
+      let mut p = peekable::PeekExt::peekable(reader);
+      let mut out = String::new();
+      let err = p.peek_to_string(&mut out).expect_err("io error expected");
+      assert_eq!(err.kind(), std::io::ErrorKind::ConnectionReset);
+      assert_eq!(out, "hel");
+  }
+
+  #[test]
+  fn peek_to_string_leaves_buf_unchanged_when_partial_bytes_are_invalid_utf8() {
+      // Emit the first two bytes of a 3-byte UTF-8 codepoint (0xE2 0x82 0xAC = €),
+      // then error.
+      let reader = ErroringReader::new(vec![0xE2, 0x82, 0xAC], 2, std::io::ErrorKind::ConnectionReset);
+      let mut p = peekable::PeekExt::peekable(reader);
+      let mut out = String::from("prefix:");
+      let err = p.peek_to_string(&mut out).expect_err("io error expected");
+      assert_eq!(err.kind(), std::io::ErrorKind::ConnectionReset);
+      assert_eq!(out, "prefix:", "buf must be unchanged when accumulated bytes aren't valid UTF-8");
+  }
+
+  #[test]
+  fn peek_to_string_returns_invalid_data_for_clean_invalid_utf8() {
+      let reader = std::io::Cursor::new(vec![0xFF, 0xFE]);
+      let mut p = peekable::PeekExt::peekable(reader);
+      let mut out = String::from("prefix:");
+      let err = p.peek_to_string(&mut out).expect_err("must fail");
+      assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+      assert_eq!(out, "prefix:");
+  }
+  ```
+
+- [ ] **Step 2: Rewrite `peek_to_string` using Pattern B + validity table.**
+
+  ```rust
+  pub fn peek_to_string(&mut self, buf: &mut String) -> Result<usize> {
+      // Up-front: definitively invalid UTF-8 in the existing peek buffer
+      // is a hard error; an incomplete trailing multi-byte sequence is
+      // allowed (newly read bytes may complete it).
+      if let Err(e) = core::str::from_utf8(self.buffer.as_slice()) {
+          if e.error_len().is_some() {
+              return Err(invalid_utf8_io_error(e));
+          }
+      }
+
+      let loop_result: Result<()> = loop {
+          let old_len = self.buffer.len();
+          if self.buffer.resize(old_len + READ_CHUNK).is_err() {
+              // A buffer-growth failure is itself an I/O error; treat it
+              // the same as an I/O error from the reader — preserve the
+              // partial valid-UTF-8 prefix.
+              break Err(std::io::Error::new(
+                  std::io::ErrorKind::OutOfMemory,
+                  "peek buffer could not grow",
+              ));
+          }
+          match self.reader.read(&mut self.buffer.as_mut_slice()[old_len..]) {
+              Ok(0) => {
+                  self.buffer.truncate(old_len);
+                  break Ok(());
+              }
+              Ok(n) => {
+                  self.buffer.truncate(old_len + n);
+              }
+              Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                  self.buffer.truncate(old_len);
+                  continue;
+              }
+              Err(e) => {
+                  self.buffer.truncate(old_len);
+                  break Err(e);
+              }
+          }
+      };
+
+      match (loop_result, core::str::from_utf8(self.buffer.as_slice())) {
+          (Ok(()), Ok(s)) => {
+              buf.push_str(s);
+              Ok(self.buffer.len())
+          }
+          (Ok(()), Err(e)) => Err(invalid_utf8_io_error(e)),
+          (Err(io), Ok(s)) => {
+              buf.push_str(s);
+              Err(io)
+          }
+          (Err(io), Err(_)) => Err(io),
+      }
+  }
+  ```
+
+  **Doc update (lib.rs:710-716):** Replace the "# Errors" block to match std semantics:
+
+  ```rust
+  /// # Errors
+  ///
+  /// If the data in this stream is *not* valid UTF-8 then an error is
+  /// returned and `buf` is unchanged.
+  ///
+  /// If an I/O error occurs, whatever bytes have been consumed so far
+  /// remain in the internal peek buffer. Any valid-UTF-8 prefix of
+  /// those bytes is appended to `buf` before the error is returned,
+  /// matching [`std::io::Read::read_to_string`]'s contract.
+  ```
+
+- [ ] **Step 3: Run tests.**
+  ```bash
+  cargo test --test sync peek_to_string
+  cargo test --lib
+  ```
+
+- [ ] **Step 4: Commit.**
+  ```bash
+  git commit -am "fix(sync): peek_to_string preserves partial valid UTF-8 on I/O error; std-compat"
+  ```
+
+---
+
+## Task 6 — Futures async wrappers + test helpers
+
+**Files:** `tests/futures_io.rs`
+
+- [ ] **Step 1: Add `BoundedBuffer` (copy) and an async `ErroringReader` wrapper in `tests/futures_io.rs`.**
+
+  ```rust
+  struct AsyncErroringReader { inner: ErroringReader }
+  impl futures_util::io::AsyncRead for AsyncErroringReader {
+      fn poll_read(
+          mut self: std::pin::Pin<&mut Self>,
+          _: &mut std::task::Context<'_>,
+          buf: &mut [u8],
+      ) -> std::task::Poll<std::io::Result<usize>> {
+          std::task::Poll::Ready(std::io::Read::read(&mut self.inner, buf))
+      }
+  }
+  ```
+
+- [ ] **Step 2: Commit.**
+  ```bash
+  git commit -am "test(futures): add async BoundedBuffer/ErroringReader helpers"
+  ```
+
+---
+
+## Task 7 — Futures `poll_peek`, `peek_exact`, `peek_to_end`, `peek_to_string`
+
+- [ ] **Step 1: Rewrite `src/future.rs:237-290` `poll_peek`.**
+
+  Keep the "buffer already has data" branches intact. For both remaining paths (Greater + no-buffer), use Pattern A and ensure `truncate` on every error / Pending path where `resize` bumped the length. (Some paths already do this — verify after edits.)
+
+- [ ] **Step 2: Rewrite `src/future/peek_exact.rs` using Pattern A.**
+
+  In each `poll` iteration, track `old_len = this.peekable.buffer.len()`, `want = total - this.filled`, call `resize(old_len + want)?`, `poll_read` into the buffer tail, truncate on return, then copy from buffer tail to `this.buf[this.filled..]`. On `Pending`, `truncate(old_len)` before returning so a re-poll starts clean.
+
+- [ ] **Step 3: Rewrite `src/future/peek_to_end.rs` using Pattern B.**
+
+  Drop the `staging` field. Instead, loop: pre-resize, `poll_read` into the buffer tail, on Ok(0) truncate + finalize, on Ok(n) truncate to `old_len+n` and extend caller's `buf` by the new slice, on Err truncate + return (caller's `buf` already has everything mirrored so far). On Pending, truncate + return Pending so a re-poll starts clean.
+
+- [ ] **Step 4: Rewrite `src/future/peek_to_string.rs` using Pattern B + validity table.**
+
+  Drop `staging`. Up-front validation same as today. On Pending / Interrupted truncate the resize. On Err or EOF, apply the (loop_result, utf8_result) table in a single match.
+
+- [ ] **Step 5: Tests in `tests/futures_io.rs`** — port the four test cases from the sync tasks, using block_on:
+
+  ```rust
+  #[test]
+  fn peek_to_string_preserves_partial_valid_utf8_on_io_error() {
+      use peekable::future::AsyncPeekExt;
+      futures::executor::block_on(async {
+          let reader = AsyncErroringReader { inner: ErroringReader::new(b"hello".to_vec(), 3, std::io::ErrorKind::ConnectionReset) };
+          let mut p = reader.peekable();
+          let mut out = String::new();
+          let err = p.peek_to_string(&mut out).await.expect_err("io error");
+          assert_eq!(err.kind(), std::io::ErrorKind::ConnectionReset);
+          assert_eq!(out, "hel");
+      });
+  }
+  // ... analogous tests for the other three cases and the two
+  // fallible-buffer cases from Tasks 2/3/4.
+  ```
+
+- [ ] **Step 6: Run.**
+  ```bash
+  cargo test --test futures_io --features future
+  ```
+
+- [ ] **Step 7: Commit.**
+  ```bash
+  git commit -am "fix(futures): read-into-peek-buffer pattern; preserve partial UTF-8 on I/O error"
+  ```
+
+---
+
+## Task 8 — Tokio async wrappers + test helpers
+
+**Files:** `tests/tokio_io.rs`
+
+- [ ] **Step 1: Add `BoundedBuffer` (copy) + an async `TokioErroringReader` that implements `tokio::io::AsyncRead` by doing sync read then setting `ReadBuf` filled length.**
+
+- [ ] **Step 2: Commit helpers.**
+
+---
+
+## Task 9 — Tokio `poll_peek`, `peek_exact`, `peek_to_end`, `peek_to_string`
+
+- [ ] **Step 1: Rewrite `src/tokio.rs:221-278` `poll_peek`.**
+
+  Same two branches. `ReadBuf`-based reads: use `unfilled_mut()` on a wrapper over the peek buffer's tail or accept that tokio's `poll_read` writes into `buf: &mut ReadBuf`. The ergonomic move is:
+
+  ```rust
+  // Grow peek buffer by caller's remaining, wrap that tail in a ReadBuf,
+  // poll_read, then copy the newly filled bytes into the caller's ReadBuf.
+  let old_len = this.buffer.len();
+  let want = caller_buf.remaining();
+  this.buffer.resize(old_len + want)?;
+  let mut tail = tokio::io::ReadBuf::new(&mut this.buffer.as_mut_slice()[old_len..]);
+  match this.reader.poll_read(cx, &mut tail) {
+      Poll::Ready(Ok(())) => {
+          let n = tail.filled().len();
+          this.buffer.truncate(old_len + n);
+          caller_buf.put_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+          Poll::Ready(Ok(()))
+      }
+      Poll::Ready(Err(e)) => { this.buffer.truncate(old_len); Poll::Ready(Err(e)) }
+      Poll::Pending => { this.buffer.truncate(old_len); Poll::Pending }
+  }
+  ```
+
+  For the "buffer_len > 0 and want > buffer_len" branch, apply the same pattern but offset by `buffer_len` (the peek-buffer prefix is already put_slice'd into caller buf).
+
+- [ ] **Step 2: Rewrite `src/tokio/peek_exact.rs` using Pattern A.** Same shape as futures version; use `ReadBuf` on the peek-buffer tail.
+
+- [ ] **Step 3: Rewrite `src/tokio/peek_to_end.rs` using Pattern B.** Drop the `staging` field.
+
+- [ ] **Step 4: Rewrite `src/tokio/peek_to_string.rs` using Pattern B + validity table.** Drop the `staging` field.
+
+- [ ] **Step 5: Port tests to `tests/tokio_io.rs`.**
+  ```bash
+  cargo test --test tokio_io --features tokio
+  ```
+
+- [ ] **Step 6: Commit.**
+  ```bash
+  git commit -am "fix(tokio): read-into-peek-buffer pattern; preserve partial UTF-8 on I/O error"
+  ```
+
+---
+
+## Task 10 — Version + changelog
+
+- [ ] **Step 1: Bump `Cargo.toml` version 0.6.0 → 0.6.1.**
+
+- [ ] **Step 2: Append to `CHANGELOG.md`:**
+
+  ```markdown
+  ## 0.6.1
+
+  ### Fixed
+
+  - `peek_to_string` (sync, futures, tokio) now preserves partial
+    valid-UTF-8 text in the caller's `String` when the inner reader
+    returns an I/O error, matching `std::io::Read::read_to_string`.
+    The previous 0.6.0 behavior left `buf` unchanged on any error.
+  - Fallible `Buffer` implementations can no longer desync the inner
+    reader from the peek buffer. All read paths now grow the peek
+    buffer and read directly into its tail; the reader only advances
+    for bytes that are already recorded in the peek buffer.
+  ```
+
+- [ ] **Step 3: Final full-suite run.**
+  ```bash
+  cargo test --all-features
+  cargo clippy --all-features --all-targets -- -D warnings
+  cargo fmt --check
+  cargo doc --all-features --no-deps
+  ```
+
+- [ ] **Step 4: Commit.**
+  ```bash
+  git commit -am "chore: release 0.6.1 with peek buffer correctness fixes"
+  ```
+
+---
+
+## Notes on potentially-tricky details
+
+- **Interrupted during Pattern B:** some readers return `Interrupted` even mid-stream. The loop body must `truncate(old_len)` and `continue` rather than leaving zero-filled bytes in the peek buffer.
+- **`poll_read` spuriously yielding 0 bytes on a partial read:** async semantics allow 0-byte successful reads for certain edge cases. Treat `Ok(0)` in Pattern B as EOF (as today). If a reader can return `Ok(0)` erroneously, that's its bug.
+- **Return value of `peek_to_end`:** must remain `read + inbuf` where `inbuf` = peek buffer length at entry. Pattern B's `this.buffer.len() - 0` at end equals that sum, but verify by inspection.
+- **`mem` import in lib.rs:** `peek_exact` rewrite may remove the last use of `std::mem`. Remove the import if so — `cargo clippy -- -D warnings` will flag it.
+- **Docs-only change** on `peek_to_string` is not considered a breaking API change; 0.6.1 patch bump is appropriate.

--- a/src/future.rs
+++ b/src/future.rs
@@ -176,31 +176,36 @@ where
 
     let this = self.project();
     if buffer_len > 0 {
-      return match want_read.cmp(&buffer_len) {
-        cmp::Ordering::Less => {
-          buf.copy_from_slice(&this.buffer.as_slice()[..want_read]);
-          this.buffer.consume(..want_read);
-          return Poll::Ready(Ok(want_read));
-        }
-        cmp::Ordering::Equal => {
-          buf.copy_from_slice(this.buffer.as_slice());
+      if want_read < buffer_len {
+        buf.copy_from_slice(&this.buffer.as_slice()[..want_read]);
+        this.buffer.consume(..want_read);
+        return Poll::Ready(Ok(want_read));
+      } else if want_read == buffer_len {
+        buf.copy_from_slice(this.buffer.as_slice());
+        this.buffer.clear();
+        return Poll::Ready(Ok(want_read));
+      }
+      buf[..buffer_len].copy_from_slice(this.buffer.as_slice());
+      buf = &mut buf[buffer_len..];
+      return match this.reader.poll_read(cx, buf) {
+        Poll::Ready(Ok(bytes)) => {
           this.buffer.clear();
-          return Poll::Ready(Ok(want_read));
+          Poll::Ready(Ok(bytes + buffer_len))
         }
-        cmp::Ordering::Greater => {
-          buf[..buffer_len].copy_from_slice(this.buffer.as_slice());
-          buf = &mut buf[buffer_len..];
-          match this.reader.poll_read(cx, buf) {
-            Poll::Ready(Ok(bytes)) => {
-              this.buffer.clear();
-              Poll::Ready(Ok(bytes + buffer_len))
-            }
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Pending => {
-              this.buffer.clear();
-              Poll::Ready(Ok(buffer_len))
-            }
-          }
+        Poll::Ready(Err(_)) => {
+          // Inner errored after we'd already copied `buffer_len`
+          // bytes from the peek buffer into the caller's slice.
+          // `AsyncRead` / `Read` contracts forbid returning Err after
+          // writing bytes, so surface the partial success; the peek
+          // buffer is cleared and the caller's next poll_read will
+          // delegate to the inner reader, which will surface the
+          // persistent error on the next call.
+          this.buffer.clear();
+          Poll::Ready(Ok(buffer_len))
+        }
+        Poll::Pending => {
+          this.buffer.clear();
+          Poll::Ready(Ok(buffer_len))
         }
       };
     }
@@ -241,41 +246,47 @@ where
     let buffer_len = self.buffer.len();
 
     if buffer_len > 0 {
-      return match want_peek.cmp(&buffer_len) {
-        cmp::Ordering::Less => {
-          buf.copy_from_slice(&self.buffer.as_slice()[..want_peek]);
-          Poll::Ready(Ok(want_peek))
-        }
-        cmp::Ordering::Equal => {
-          buf.copy_from_slice(self.buffer.as_slice());
-          Poll::Ready(Ok(want_peek))
-        }
-        cmp::Ordering::Greater => {
-          let this = self.project();
-          this.buffer.resize(want_peek)?;
-          match this
-            .reader
-            .poll_read(cx, &mut this.buffer.as_mut_slice()[buffer_len..])
-          {
-            Poll::Ready(Ok(n)) => {
-              this.buffer.truncate(n + buffer_len);
-              buf[..buffer_len + n].copy_from_slice(this.buffer.as_slice());
-              Poll::Ready(Ok(buffer_len + n))
-            }
-            Poll::Ready(Err(e)) => {
-              // Roll back the resize so the peek buffer doesn't carry
-              // ghost zero-bytes past the originally peeked data.
-              this.buffer.truncate(buffer_len);
-              Poll::Ready(Err(e))
-            }
-            Poll::Pending => {
-              this.buffer.truncate(buffer_len);
-              buf[..buffer_len].copy_from_slice(this.buffer.as_slice());
-              Poll::Ready(Ok(buffer_len))
-            }
+      if want_peek < buffer_len {
+        buf.copy_from_slice(&self.buffer.as_slice()[..want_peek]);
+        return Poll::Ready(Ok(want_peek));
+      } else if want_peek == buffer_len {
+        buf.copy_from_slice(self.buffer.as_slice());
+        return Poll::Ready(Ok(want_peek));
+      }
+      let mut this = self.project();
+      this.buffer.resize(want_peek)?;
+      // Retry on `Interrupted` and convert `WouldBlock` to `Pending`
+      // per the `AsyncPeek` trait contract.
+      loop {
+        match this
+          .reader
+          .as_mut()
+          .poll_read(cx, &mut this.buffer.as_mut_slice()[buffer_len..])
+        {
+          Poll::Ready(Ok(n)) => {
+            this.buffer.truncate(n + buffer_len);
+            buf[..buffer_len + n].copy_from_slice(this.buffer.as_slice());
+            return Poll::Ready(Ok(buffer_len + n));
+          }
+          Poll::Ready(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+          Poll::Ready(Err(e)) if e.kind() == std::io::ErrorKind::WouldBlock => {
+            this.buffer.truncate(buffer_len);
+            buf[..buffer_len].copy_from_slice(this.buffer.as_slice());
+            return Poll::Ready(Ok(buffer_len));
+          }
+          Poll::Ready(Err(e)) => {
+            // Roll back the resize so the peek buffer doesn't carry
+            // ghost zero-bytes past the originally peeked data.
+            this.buffer.truncate(buffer_len);
+            return Poll::Ready(Err(e));
+          }
+          Poll::Pending => {
+            this.buffer.truncate(buffer_len);
+            buf[..buffer_len].copy_from_slice(this.buffer.as_slice());
+            return Poll::Ready(Ok(buffer_len));
           }
         }
-      };
+      }
     }
 
     if want_peek == 0 {
@@ -284,25 +295,35 @@ where
 
     // Read directly into the peek buffer's tail so the reader only
     // advances for bytes already recorded for replay.
-    let this = self.project();
+    let mut this = self.project();
     let old_len = this.buffer.len();
     this.buffer.resize(old_len + want_peek)?;
-    match this
-      .reader
-      .poll_read(cx, &mut this.buffer.as_mut_slice()[old_len..])
-    {
-      Poll::Ready(Ok(n)) => {
-        this.buffer.truncate(old_len + n);
-        buf[..n].copy_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
-        Poll::Ready(Ok(n))
-      }
-      Poll::Ready(Err(e)) => {
-        this.buffer.truncate(old_len);
-        Poll::Ready(Err(e))
-      }
-      Poll::Pending => {
-        this.buffer.truncate(old_len);
-        Poll::Pending
+    // Retry on `Interrupted` and convert `WouldBlock` to `Pending`
+    // per the `AsyncPeek` trait contract.
+    loop {
+      match this
+        .reader
+        .as_mut()
+        .poll_read(cx, &mut this.buffer.as_mut_slice()[old_len..])
+      {
+        Poll::Ready(Ok(n)) => {
+          this.buffer.truncate(old_len + n);
+          buf[..n].copy_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+          return Poll::Ready(Ok(n));
+        }
+        Poll::Ready(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+        Poll::Ready(Err(e)) if e.kind() == std::io::ErrorKind::WouldBlock => {
+          this.buffer.truncate(old_len);
+          return Poll::Pending;
+        }
+        Poll::Ready(Err(e)) => {
+          this.buffer.truncate(old_len);
+          return Poll::Ready(Err(e));
+        }
+        Poll::Pending => {
+          this.buffer.truncate(old_len);
+          return Poll::Pending;
+        }
       }
     }
   }

--- a/src/future.rs
+++ b/src/future.rs
@@ -278,14 +278,32 @@ where
       };
     }
 
+    if want_peek == 0 {
+      return Poll::Ready(Ok(0));
+    }
+
+    // Read directly into the peek buffer's tail so the reader only
+    // advances for bytes already recorded for replay.
     let this = self.project();
-    match this.reader.poll_read(cx, buf) {
-      Poll::Ready(Ok(bytes)) => {
-        this.buffer.extend_from_slice(&buf[..bytes])?;
-        Poll::Ready(Ok(bytes))
+    let old_len = this.buffer.len();
+    this.buffer.resize(old_len + want_peek)?;
+    match this
+      .reader
+      .poll_read(cx, &mut this.buffer.as_mut_slice()[old_len..])
+    {
+      Poll::Ready(Ok(n)) => {
+        this.buffer.truncate(old_len + n);
+        buf[..n].copy_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+        Poll::Ready(Ok(n))
       }
-      Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-      Poll::Pending => Poll::Pending,
+      Poll::Ready(Err(e)) => {
+        this.buffer.truncate(old_len);
+        Poll::Ready(Err(e))
+      }
+      Poll::Pending => {
+        this.buffer.truncate(old_len);
+        Poll::Pending
+      }
     }
   }
 }

--- a/src/future/peek_exact.rs
+++ b/src/future/peek_exact.rs
@@ -50,31 +50,38 @@ impl<P: AsyncRead + Unpin, B: Buffer> Future for PeekExact<'_, P, B> {
       }
     }
 
-    // Read from the inner reader into the unfilled portion of `buf`.
+    // Read from the inner reader directly into the peek buffer's
+    // tail, then copy newly-produced bytes into the caller's buf.
+    // The reader only advances for bytes already recorded for replay.
     while this.filled < total {
-      let n = match Pin::new(&mut this.peekable.reader).poll_read(cx, &mut this.buf[this.filled..])
+      let old_len = this.peekable.buffer.len();
+      let want = total - this.filled;
+      this.peekable.buffer.resize(old_len + want)?;
+
+      let n = match Pin::new(&mut this.peekable.reader)
+        .poll_read(cx, &mut this.peekable.buffer.as_mut_slice()[old_len..])
       {
         Poll::Ready(Ok(n)) => n,
-        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => continue,
-        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-        Poll::Pending => return Poll::Pending,
+        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+          this.peekable.buffer.truncate(old_len);
+          continue;
+        }
+        Poll::Ready(Err(e)) => {
+          this.peekable.buffer.truncate(old_len);
+          return Poll::Ready(Err(e));
+        }
+        Poll::Pending => {
+          this.peekable.buffer.truncate(old_len);
+          return Poll::Pending;
+        }
       };
 
+      this.peekable.buffer.truncate(old_len + n);
       if n == 0 {
         return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into()));
       }
-
-      // Mirror the newly-read bytes into the peek buffer so the
-      // peek abstraction is maintained.
-      //
-      // TODO(al8n): if `extend_from_slice` fails, the bytes are in
-      // `buf` but not in the peek buffer — breaking the abstraction
-      // for custom Buffer impls. Same future-improvement as noted in
-      // peek_to_end.rs and peek_to_string.rs.
-      this
-        .peekable
-        .buffer
-        .extend_from_slice(&this.buf[this.filled..this.filled + n])?;
+      this.buf[this.filled..this.filled + n]
+        .copy_from_slice(&this.peekable.buffer.as_slice()[old_len..old_len + n]);
       this.filled += n;
     }
 

--- a/src/future/peek_to_end.rs
+++ b/src/future/peek_to_end.rs
@@ -42,9 +42,7 @@ where
     let this = &mut *self;
 
     if !this.prefix_copied {
-      this
-        .buf
-        .extend_from_slice(this.peekable.buffer.as_slice());
+      this.buf.extend_from_slice(this.peekable.buffer.as_slice());
       this.prefix_copied = true;
     }
 

--- a/src/future/peek_to_end.rs
+++ b/src/future/peek_to_end.rs
@@ -1,7 +1,7 @@
 use futures_util::AsyncRead;
 
 use super::{AsyncPeekable, Buffer, DefaultBuffer};
-use crate::StagingBuf;
+use crate::READ_CHUNK;
 use std::{
   future::Future,
   io,
@@ -15,30 +15,18 @@ use std::{
 pub struct PeekToEnd<'a, P, B = DefaultBuffer> {
   peekable: &'a mut AsyncPeekable<P, B>,
   buf: &'a mut Vec<u8>,
-  /// Peek-buffer length at creation time. Stored once so the return
-  /// value isn't inflated by chunks mirrored into the peek buffer
-  /// during earlier polls.
-  initial_peek_len: usize,
-  /// Position in `buf` where reader-provided data starts, or `None`
-  /// if the peek-buffer prefix has not yet been copied into `buf`.
-  reader_data_start: Option<usize>,
-  /// Staging buffer for `poll_read`. Inline (via SmallVec or a
-  /// fixed-size wrapper) so no separate heap allocation is needed
-  /// for small reads.
-  staging: StagingBuf,
+  /// `true` once the peek-buffer prefix has been copied into `buf`.
+  prefix_copied: bool,
 }
 
 impl<P: Unpin, B> Unpin for PeekToEnd<'_, P, B> {}
 
 impl<'a, P: AsyncRead + Unpin, B: Buffer> PeekToEnd<'a, P, B> {
   pub(super) fn new(peekable: &'a mut AsyncPeekable<P, B>, buf: &'a mut Vec<u8>) -> Self {
-    let initial_peek_len = peekable.buffer.len();
     Self {
       peekable,
       buf,
-      initial_peek_len,
-      reader_data_start: None,
-      staging: crate::new_staging_buf(),
+      prefix_copied: false,
     }
   }
 }
@@ -52,43 +40,45 @@ where
 
   fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
     let this = &mut *self;
-    let inbuf = this.initial_peek_len;
 
-    let reader_start = match this.reader_data_start {
-      Some(pos) => pos,
-      None => {
-        this.buf.extend_from_slice(this.peekable.buffer.as_slice());
-        let pos = this.buf.len();
-        this.reader_data_start = Some(pos);
-        pos
-      }
-    };
+    if !this.prefix_copied {
+      this
+        .buf
+        .extend_from_slice(this.peekable.buffer.as_slice());
+      this.prefix_copied = true;
+    }
 
     loop {
-      match Pin::new(&mut this.peekable.reader).poll_read(cx, &mut this.staging) {
+      let old_len = this.peekable.buffer.len();
+      this.peekable.buffer.resize(old_len + READ_CHUNK)?;
+      match Pin::new(&mut this.peekable.reader)
+        .poll_read(cx, &mut this.peekable.buffer.as_mut_slice()[old_len..])
+      {
         Poll::Ready(Ok(0)) => {
-          // EOF — all chunks already mirrored incrementally.
-          return Poll::Ready(Ok(inbuf + (this.buf.len() - reader_start)));
+          this.peekable.buffer.truncate(old_len);
+          return Poll::Ready(Ok(this.peekable.buffer.len()));
         }
         Poll::Ready(Ok(n)) => {
-          let chunk = &this.staging[..n];
-          // TODO(al8n): if extend_from_slice fails, the peek buffer
-          // won't have these bytes. A future improvement could read
-          // directly into the peek buffer's tail (resize + poll_read
-          // into buffer.as_mut_slice()[old_len..]) to eliminate this.
-          // At least give the caller the data in buf (matching
-          // read_to_end's partial-data-on-error contract).
-          if let Err(e) = this.peekable.buffer.extend_from_slice(chunk) {
-            this.buf.extend_from_slice(chunk);
-            return Poll::Ready(Err(e));
-          }
-          this.buf.extend_from_slice(chunk);
+          this.peekable.buffer.truncate(old_len + n);
+          this
+            .buf
+            .extend_from_slice(&this.peekable.buffer.as_slice()[old_len..old_len + n]);
         }
-        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => continue,
-        // Leave partial data in buf — matches std/tokio's
-        // read_to_end contract.
-        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-        Poll::Pending => return Poll::Pending,
+        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+          this.peekable.buffer.truncate(old_len);
+          continue;
+        }
+        Poll::Ready(Err(e)) => {
+          // Partial data already mirrored into both the peek buffer
+          // (prior iterations) and `buf`. Leave it in `buf` — matches
+          // std/tokio's `read_to_end` partial-data-on-error contract.
+          this.peekable.buffer.truncate(old_len);
+          return Poll::Ready(Err(e));
+        }
+        Poll::Pending => {
+          this.peekable.buffer.truncate(old_len);
+          return Poll::Pending;
+        }
       }
     }
   }

--- a/src/future/peek_to_end.rs
+++ b/src/future/peek_to_end.rs
@@ -1,7 +1,7 @@
 use futures_util::AsyncRead;
 
 use super::{AsyncPeekable, Buffer, DefaultBuffer};
-use crate::READ_CHUNK;
+use crate::grow_peek_buffer;
 use std::{
   future::Future,
   io,
@@ -48,10 +48,11 @@ where
 
     loop {
       let old_len = this.peekable.buffer.len();
-      this.peekable.buffer.resize(old_len + READ_CHUNK)?;
-      match Pin::new(&mut this.peekable.reader)
-        .poll_read(cx, &mut this.peekable.buffer.as_mut_slice()[old_len..])
-      {
+      let growth = grow_peek_buffer(&mut this.peekable.buffer)?;
+      match Pin::new(&mut this.peekable.reader).poll_read(
+        cx,
+        &mut this.peekable.buffer.as_mut_slice()[old_len..old_len + growth],
+      ) {
         Poll::Ready(Ok(0)) => {
           this.peekable.buffer.truncate(old_len);
           return Poll::Ready(Ok(this.peekable.buffer.len()));

--- a/src/future/peek_to_string.rs
+++ b/src/future/peek_to_string.rs
@@ -1,7 +1,7 @@
 use futures_util::AsyncRead;
 
 use super::{AsyncPeekable, Buffer, DefaultBuffer};
-use crate::READ_CHUNK;
+use crate::grow_peek_buffer;
 use std::{
   future::Future,
   io,
@@ -60,35 +60,34 @@ where
     // longest valid prefix on an I/O error (matching std semantics).
     loop {
       let old_len = this.peekable.buffer.len();
-      let loop_result: io::Result<()> =
-        if let Err(e) = this.peekable.buffer.resize(old_len + READ_CHUNK) {
-          Err(e)
-        } else {
-          match Pin::new(&mut this.peekable.reader)
-            .poll_read(cx, &mut this.peekable.buffer.as_mut_slice()[old_len..])
-          {
-            Poll::Ready(Ok(0)) => {
-              this.peekable.buffer.truncate(old_len);
-              Ok(())
-            }
-            Poll::Ready(Ok(n)) => {
-              this.peekable.buffer.truncate(old_len + n);
-              continue;
-            }
-            Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
-              this.peekable.buffer.truncate(old_len);
-              continue;
-            }
-            Poll::Ready(Err(e)) => {
-              this.peekable.buffer.truncate(old_len);
-              Err(e)
-            }
-            Poll::Pending => {
-              this.peekable.buffer.truncate(old_len);
-              return Poll::Pending;
-            }
+      let loop_result: io::Result<()> = match grow_peek_buffer(&mut this.peekable.buffer) {
+        Err(e) => Err(e),
+        Ok(growth) => match Pin::new(&mut this.peekable.reader).poll_read(
+          cx,
+          &mut this.peekable.buffer.as_mut_slice()[old_len..old_len + growth],
+        ) {
+          Poll::Ready(Ok(0)) => {
+            this.peekable.buffer.truncate(old_len);
+            Ok(())
           }
-        };
+          Poll::Ready(Ok(n)) => {
+            this.peekable.buffer.truncate(old_len + n);
+            continue;
+          }
+          Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+            this.peekable.buffer.truncate(old_len);
+            continue;
+          }
+          Poll::Ready(Err(e)) => {
+            this.peekable.buffer.truncate(old_len);
+            Err(e)
+          }
+          Poll::Pending => {
+            this.peekable.buffer.truncate(old_len);
+            return Poll::Pending;
+          }
+        },
+      };
 
       return Poll::Ready(
         match (
@@ -104,7 +103,19 @@ where
             this.buf.push_str(s);
             Err(io)
           }
-          (Err(io), Err(_)) => Err(io),
+          (Err(io), Err(utf8_err)) => {
+            // Preserve the longest valid-UTF-8 prefix of the
+            // consumed bytes; bytes after `valid_up_to()` are either
+            // invalid or an incomplete multi-byte sequence and are
+            // dropped from `buf` (still accessible via `get_ref()`).
+            let vut = utf8_err.valid_up_to();
+            if vut != 0 {
+              let s = core::str::from_utf8(&this.peekable.buffer.as_slice()[..vut])
+                .expect("valid_up_to() must point to a valid UTF-8 prefix");
+              this.buf.push_str(s);
+            }
+            Err(io)
+          }
         },
       );
     }

--- a/src/future/peek_to_string.rs
+++ b/src/future/peek_to_string.rs
@@ -60,39 +60,41 @@ where
     // longest valid prefix on an I/O error (matching std semantics).
     loop {
       let old_len = this.peekable.buffer.len();
-      let loop_result: io::Result<()> = if let Err(e) =
-        this.peekable.buffer.resize(old_len + READ_CHUNK)
-      {
-        Err(e)
-      } else {
-        match Pin::new(&mut this.peekable.reader)
-          .poll_read(cx, &mut this.peekable.buffer.as_mut_slice()[old_len..])
-        {
-          Poll::Ready(Ok(0)) => {
-            this.peekable.buffer.truncate(old_len);
-            Ok(())
+      let loop_result: io::Result<()> =
+        if let Err(e) = this.peekable.buffer.resize(old_len + READ_CHUNK) {
+          Err(e)
+        } else {
+          match Pin::new(&mut this.peekable.reader)
+            .poll_read(cx, &mut this.peekable.buffer.as_mut_slice()[old_len..])
+          {
+            Poll::Ready(Ok(0)) => {
+              this.peekable.buffer.truncate(old_len);
+              Ok(())
+            }
+            Poll::Ready(Ok(n)) => {
+              this.peekable.buffer.truncate(old_len + n);
+              continue;
+            }
+            Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+              this.peekable.buffer.truncate(old_len);
+              continue;
+            }
+            Poll::Ready(Err(e)) => {
+              this.peekable.buffer.truncate(old_len);
+              Err(e)
+            }
+            Poll::Pending => {
+              this.peekable.buffer.truncate(old_len);
+              return Poll::Pending;
+            }
           }
-          Poll::Ready(Ok(n)) => {
-            this.peekable.buffer.truncate(old_len + n);
-            continue;
-          }
-          Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
-            this.peekable.buffer.truncate(old_len);
-            continue;
-          }
-          Poll::Ready(Err(e)) => {
-            this.peekable.buffer.truncate(old_len);
-            Err(e)
-          }
-          Poll::Pending => {
-            this.peekable.buffer.truncate(old_len);
-            return Poll::Pending;
-          }
-        }
-      };
+        };
 
       return Poll::Ready(
-        match (loop_result, core::str::from_utf8(this.peekable.buffer.as_slice())) {
+        match (
+          loop_result,
+          core::str::from_utf8(this.peekable.buffer.as_slice()),
+        ) {
           (Ok(()), Ok(s)) => {
             this.buf.push_str(s);
             Ok(this.peekable.buffer.len())

--- a/src/future/peek_to_string.rs
+++ b/src/future/peek_to_string.rs
@@ -1,7 +1,7 @@
 use futures_util::AsyncRead;
 
 use super::{AsyncPeekable, Buffer, DefaultBuffer};
-use crate::StagingBuf;
+use crate::READ_CHUNK;
 use std::{
   future::Future,
   io,
@@ -17,8 +17,6 @@ pub struct PeekToString<'a, P, B = DefaultBuffer> {
   buf: &'a mut String,
   /// `true` once the peek-buffer prefix has been validated.
   started: bool,
-  /// Staging buffer for `poll_read` — inline for small reads.
-  staging: StagingBuf,
 }
 
 impl<P: Unpin, B> Unpin for PeekToString<'_, P, B> {}
@@ -29,7 +27,6 @@ impl<'a, P: AsyncRead + Unpin, B: Buffer> PeekToString<'a, P, B> {
       peekable,
       buf,
       started: false,
-      staging: crate::new_staging_buf(),
     }
   }
 }
@@ -57,36 +54,57 @@ where
       this.started = true;
     }
 
-    // Read from the inner reader and accumulate directly into the
-    // peek buffer — no separate `raw: Vec<u8>` needed. This keeps
-    // peak memory at ~2× stream size (peek buffer + caller String)
-    // instead of ~3× (peek buffer + raw + caller String).
+    // Read directly into the peek buffer's tail so the reader only
+    // advances for bytes recorded for replay. Accumulate the reader
+    // outcome; validate UTF-8 after the loop so we can preserve the
+    // longest valid prefix on an I/O error (matching std semantics).
     loop {
-      match Pin::new(&mut this.peekable.reader).poll_read(cx, &mut this.staging) {
-        Poll::Ready(Ok(0)) => {
-          // EOF. Validate the full peek buffer as UTF-8.
-          let s = match core::str::from_utf8(this.peekable.buffer.as_slice()) {
-            Ok(s) => s,
-            Err(e) => return Poll::Ready(Err(super::invalid_utf8_io_error(e))),
-          };
-          this.buf.push_str(s);
-          return Poll::Ready(Ok(this.peekable.buffer.len()));
+      let old_len = this.peekable.buffer.len();
+      let loop_result: io::Result<()> = if let Err(e) =
+        this.peekable.buffer.resize(old_len + READ_CHUNK)
+      {
+        Err(e)
+      } else {
+        match Pin::new(&mut this.peekable.reader)
+          .poll_read(cx, &mut this.peekable.buffer.as_mut_slice()[old_len..])
+        {
+          Poll::Ready(Ok(0)) => {
+            this.peekable.buffer.truncate(old_len);
+            Ok(())
+          }
+          Poll::Ready(Ok(n)) => {
+            this.peekable.buffer.truncate(old_len + n);
+            continue;
+          }
+          Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+            this.peekable.buffer.truncate(old_len);
+            continue;
+          }
+          Poll::Ready(Err(e)) => {
+            this.peekable.buffer.truncate(old_len);
+            Err(e)
+          }
+          Poll::Pending => {
+            this.peekable.buffer.truncate(old_len);
+            return Poll::Pending;
+          }
         }
-        Poll::Ready(Ok(n)) => {
-          // TODO(al8n): if `extend_from_slice` fails here, the bytes in
-          // `staging[..n]` are lost — the reader already consumed
-          // them but they can't be stored in the peek buffer. A
-          // future improvement could read directly into the peek
-          // buffer's tail (via `resize` + `poll_read` into
-          // `buffer.as_mut_slice()[old_len..]`) to eliminate this
-          // window, at the cost of splitting the mutable borrow
-          // across `peekable.reader` and `peekable.buffer`.
-          this.peekable.buffer.extend_from_slice(&this.staging[..n])?;
-        }
-        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => continue,
-        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-        Poll::Pending => return Poll::Pending,
-      }
+      };
+
+      return Poll::Ready(
+        match (loop_result, core::str::from_utf8(this.peekable.buffer.as_slice())) {
+          (Ok(()), Ok(s)) => {
+            this.buf.push_str(s);
+            Ok(this.peekable.buffer.len())
+          }
+          (Ok(()), Err(e)) => Err(super::invalid_utf8_io_error(e)),
+          (Err(io), Ok(s)) => {
+            this.buf.push_str(s);
+            Err(io)
+          }
+          (Err(io), Err(_)) => Err(io),
+        },
+      );
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,79 +19,10 @@ pub type DefaultBuffer = smallvec::SmallVec<[u8; 64]>;
 pub type DefaultBuffer = Vec<u8>;
 
 /// Chunk size used by `peek_to_end` / `peek_to_string` for growing
-/// the peek buffer in unbounded read loops, and as the fixed staging
-/// buffer size for async `poll_read` when the `tokio`/`future` feature
-/// is enabled.
+/// the peek buffer in unbounded read loops. Applies to both sync and
+/// async implementations — the peek buffer itself is now the staging
+/// area, so no separate fixed-size staging buffer is needed.
 const READ_CHUNK: usize = 1024;
-
-#[cfg(any(feature = "tokio", feature = "future"))]
-const STAGING_CAP: usize = READ_CHUNK;
-
-/// A fixed-capacity byte buffer for `poll_read` staging in the async
-/// peek futures. Stored as a field in the future struct rather than a
-/// stack-local array, so `poll()` adds zero stack pressure — important
-/// for executors with small per-task stacks.
-///
-/// When the `smallvec` feature is enabled, this is
-/// `SmallVec<[u8; 1024]>` — the bytes live inline in the future struct.
-/// In this crate it is used as a fixed-size 1024-byte staging buffer.
-///
-/// Without `smallvec`, a minimal inline wrapper provides the same
-/// fixed 1024-byte semantics with no heap allocation of its own.
-#[cfg(all(feature = "smallvec", any(feature = "tokio", feature = "future")))]
-pub(crate) type StagingBuf = smallvec::SmallVec<[u8; STAGING_CAP]>;
-
-#[cfg(all(not(feature = "smallvec"), any(feature = "tokio", feature = "future")))]
-pub(crate) struct StagingBuf {
-  buf: [u8; STAGING_CAP],
-}
-
-#[cfg(all(not(feature = "smallvec"), any(feature = "tokio", feature = "future")))]
-impl StagingBuf {
-  /// Creates a new zeroed staging buffer.
-  pub(crate) fn new() -> Self {
-    Self {
-      buf: [0u8; STAGING_CAP],
-    }
-  }
-}
-
-#[cfg(all(not(feature = "smallvec"), any(feature = "tokio", feature = "future")))]
-impl core::ops::Deref for StagingBuf {
-  type Target = [u8];
-  fn deref(&self) -> &[u8] {
-    &self.buf
-  }
-}
-
-#[cfg(all(not(feature = "smallvec"), any(feature = "tokio", feature = "future")))]
-impl core::ops::DerefMut for StagingBuf {
-  fn deref_mut(&mut self) -> &mut [u8] {
-    &mut self.buf
-  }
-}
-
-#[cfg(all(not(feature = "smallvec"), any(feature = "tokio", feature = "future")))]
-impl core::fmt::Debug for StagingBuf {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    f.debug_struct("StagingBuf")
-      .field("cap", &STAGING_CAP)
-      .finish()
-  }
-}
-
-/// Construct a new [`StagingBuf`].
-#[cfg(any(feature = "tokio", feature = "future"))]
-pub(crate) fn new_staging_buf() -> StagingBuf {
-  #[cfg(feature = "smallvec")]
-  {
-    smallvec::smallvec![0u8; STAGING_CAP]
-  }
-  #[cfg(not(feature = "smallvec"))]
-  {
-    StagingBuf::new()
-  }
-}
 
 /// Extracts the successful type of a `Poll<T>`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 
 use buffer::Buffer;
 use std::{
-  cmp,
   io::{IoSliceMut, Read, Result, Write},
   mem,
 };
@@ -85,29 +84,29 @@ where
     // check if the peek buffer has data
     let buffer_len = peek_buf.len();
     if buffer_len > 0 {
-      return match want_peek.cmp(&buffer_len) {
-        cmp::Ordering::Less => {
-          buf.copy_from_slice(&peek_buf[..want_peek]);
-          this.buffer.consume(..want_peek);
-          return Ok(want_peek);
-        }
-        cmp::Ordering::Equal => {
-          buf.copy_from_slice(peek_buf);
-          this.buffer.clear();
-          return Ok(want_peek);
-        }
-        cmp::Ordering::Greater => {
-          buf[..buffer_len].copy_from_slice(peek_buf);
-          buf = &mut buf[buffer_len..];
-          match this.reader.read(buf) {
-            Ok(bytes) => {
-              this.buffer.clear();
-              Ok(bytes + buffer_len)
-            }
-            Err(e) => Err(e),
-          }
-        }
-      };
+      if want_peek < buffer_len {
+        buf.copy_from_slice(&peek_buf[..want_peek]);
+        this.buffer.consume(..want_peek);
+        return Ok(want_peek);
+      } else if want_peek == buffer_len {
+        buf.copy_from_slice(peek_buf);
+        this.buffer.clear();
+        return Ok(want_peek);
+      } else {
+        buf[..buffer_len].copy_from_slice(peek_buf);
+        buf = &mut buf[buffer_len..];
+        let result = this.reader.read(buf);
+        // Always clear: the peek buffer's contents have been
+        // delivered to the caller. `Read` contract forbids returning
+        // Err after writing bytes, so surface the partial success on
+        // inner error; the caller's next read() will delegate to the
+        // inner reader and see the persistent error then.
+        this.buffer.clear();
+        return match result {
+          Ok(bytes) => Ok(bytes + buffer_len),
+          Err(_) => Ok(buffer_len),
+        };
+      }
     }
 
     this.reader.read(buf)
@@ -488,42 +487,38 @@ where
     let buffer_len = self.buffer.len();
 
     if buffer_len > 0 {
-      return match want_peek.cmp(&buffer_len) {
-        cmp::Ordering::Less => {
-          buf.copy_from_slice(&self.buffer.as_slice()[..want_peek]);
-          Ok(want_peek)
+      if want_peek < buffer_len {
+        buf.copy_from_slice(&self.buffer.as_slice()[..want_peek]);
+        return Ok(want_peek);
+      } else if want_peek == buffer_len {
+        buf.copy_from_slice(self.buffer.as_slice());
+        return Ok(want_peek);
+      }
+      // Need to top up from the reader.
+      self.buffer.resize(want_peek)?;
+      // Retry on `Interrupted` per the documented contract.
+      let result = loop {
+        match self
+          .reader
+          .read(&mut self.buffer.as_mut_slice()[buffer_len..])
+        {
+          Ok(n) => break Ok(n),
+          Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+          Err(e) => break Err(e),
         }
-        cmp::Ordering::Equal => {
-          buf.copy_from_slice(self.buffer.as_slice());
-          Ok(want_peek)
+      };
+      return match result {
+        Ok(n) => {
+          self.buffer.truncate(n + buffer_len);
+          buf[..buffer_len + n].copy_from_slice(self.buffer.as_slice());
+          Ok(buffer_len + n)
         }
-        cmp::Ordering::Greater => {
-          self.buffer.resize(want_peek)?;
-          // Retry on `Interrupted` per the documented contract.
-          let result = loop {
-            match self
-              .reader
-              .read(&mut self.buffer.as_mut_slice()[buffer_len..])
-            {
-              Ok(n) => break Ok(n),
-              Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-              Err(e) => break Err(e),
-            }
-          };
-          match result {
-            Ok(n) => {
-              self.buffer.truncate(n + buffer_len);
-              buf[..buffer_len + n].copy_from_slice(self.buffer.as_slice());
-              Ok(buffer_len + n)
-            }
-            Err(e) => {
-              // Roll back the resize so the peek buffer doesn't carry
-              // ghost zero-bytes that a subsequent call would return as
-              // "real" peeked data.
-              self.buffer.truncate(buffer_len);
-              Err(e)
-            }
-          }
+        Err(e) => {
+          // Roll back the resize so the peek buffer doesn't carry
+          // ghost zero-bytes that a subsequent call would return as
+          // "real" peeked data.
+          self.buffer.truncate(buffer_len);
+          Err(e)
         }
       };
     }
@@ -633,8 +628,11 @@ where
 
     loop {
       let old_len = this.buffer.len();
-      this.buffer.resize(old_len + READ_CHUNK)?;
-      match this.reader.read(&mut this.buffer.as_mut_slice()[old_len..]) {
+      let growth = grow_peek_buffer(&mut this.buffer)?;
+      match this
+        .reader
+        .read(&mut this.buffer.as_mut_slice()[old_len..old_len + growth])
+      {
         Ok(0) => {
           this.buffer.truncate(old_len);
           return Ok(this.buffer.len());
@@ -671,10 +669,15 @@ where
   /// If an I/O error occurs, any bytes the reader has already produced
   /// remain in the internal peek buffer (accessible via
   /// [`get_ref`](Self::get_ref)). The longest valid-UTF-8 prefix of
-  /// those bytes is appended to `buf` before the error is returned,
-  /// matching [`std::io::Read::read_to_string`]'s contract. If the
-  /// prefix is not valid UTF-8 (e.g. the reader errored mid multi-byte
-  /// sequence), `buf` is left unchanged.
+  /// those bytes is appended to `buf` before the error is returned.
+  /// If the reader errored in the middle of a multi-byte UTF-8
+  /// sequence, the bytes up to — but not including — the incomplete
+  /// sequence are appended; the incomplete bytes are dropped from
+  /// `buf` but remain available in the peek buffer. This is slightly
+  /// more permissive than [`std::io::Read::read_to_string`], which
+  /// would drop the entire segment; the peek-buffer abstraction lets
+  /// us preserve more data without corrupting `String`'s UTF-8
+  /// invariant.
   ///
   /// [`peek_to_end`]: Peek::peek_to_end
   ///
@@ -728,10 +731,14 @@ where
     // we still want to preserve the longest valid-UTF-8 prefix.
     let loop_result: Result<()> = loop {
       let old_len = self.buffer.len();
-      if let Err(e) = self.buffer.resize(old_len + READ_CHUNK) {
-        break Err(e);
-      }
-      match self.reader.read(&mut self.buffer.as_mut_slice()[old_len..]) {
+      let growth = match grow_peek_buffer(&mut self.buffer) {
+        Ok(g) => g,
+        Err(e) => break Err(e),
+      };
+      match self
+        .reader
+        .read(&mut self.buffer.as_mut_slice()[old_len..old_len + growth])
+      {
         Ok(0) => {
           self.buffer.truncate(old_len);
           break Ok(());
@@ -760,7 +767,20 @@ where
         buf.push_str(s);
         Err(io)
       }
-      (Err(io), Err(_)) => Err(io),
+      (Err(io), Err(utf8_err)) => {
+        // Preserve the longest valid-UTF-8 prefix: bytes before
+        // `valid_up_to()` are guaranteed to be a complete valid
+        // UTF-8 sequence. The bytes after are either invalid or an
+        // incomplete multi-byte sequence — dropped from `buf` but
+        // still available in the peek buffer via `get_ref()`.
+        let vut = utf8_err.valid_up_to();
+        if vut != 0 {
+          let s = core::str::from_utf8(&self.buffer.as_slice()[..vut])
+            .expect("valid_up_to() must point to a valid UTF-8 prefix");
+          buf.push_str(s);
+        }
+        Err(io)
+      }
     }
   }
 
@@ -983,6 +1003,30 @@ impl<R: Read + ?Sized> PeekExt for R {}
 #[cfg_attr(not(tarpaulin), inline(always))]
 fn invalid_utf8_io_error(e: core::str::Utf8Error) -> std::io::Error {
   std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+}
+
+/// Grow the peek buffer by up to `READ_CHUNK` bytes, halving the
+/// requested growth on each [`Buffer::resize`] failure down to 1.
+/// Returns the growth that actually succeeded, or the last error
+/// if no growth by ≥ 1 byte is possible.
+///
+/// Used by the unbounded-size `peek_to_end` / `peek_to_string` paths
+/// so they work with small-capacity fallible `Buffer` implementations
+/// when the remaining stream fits. A bounded `Buffer` whose capacity
+/// is strictly greater than the final stream size will succeed; the
+/// pathological case — capacity exactly equal to stream size — still
+/// fails, because detecting EOF requires reading one more byte.
+#[cfg_attr(not(tarpaulin), inline)]
+pub(crate) fn grow_peek_buffer<B: Buffer>(buffer: &mut B) -> std::io::Result<usize> {
+  let old_len = buffer.len();
+  let mut growth = READ_CHUNK;
+  loop {
+    match buffer.resize(old_len + growth) {
+      Ok(()) => return Ok(growth),
+      Err(_) if growth > 1 => growth /= 2,
+      Err(e) => return Err(e),
+    }
+  }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,14 @@ pub type DefaultBuffer = smallvec::SmallVec<[u8; 64]>;
 #[cfg(not(feature = "smallvec"))]
 pub type DefaultBuffer = Vec<u8>;
 
-/// Staging-buffer capacity used by async `peek_to_end` / `peek_to_string`.
+/// Chunk size used by `peek_to_end` / `peek_to_string` for growing
+/// the peek buffer in unbounded read loops, and as the fixed staging
+/// buffer size for async `poll_read` when the `tokio`/`future` feature
+/// is enabled.
+const READ_CHUNK: usize = 1024;
+
 #[cfg(any(feature = "tokio", feature = "future"))]
-const STAGING_CAP: usize = 1024;
+const STAGING_CAP: usize = READ_CHUNK;
 
 /// A fixed-capacity byte buffer for `poll_read` staging in the async
 /// peek futures. Stored as a field in the future struct rather than a
@@ -592,15 +597,29 @@ where
       };
     }
 
+    if want_peek == 0 {
+      return Ok(0);
+    }
+
+    // Read directly into the peek buffer's tail so the inner reader
+    // only advances for bytes that are already recorded for replay —
+    // a fallible Buffer can fail on `resize` before we touch the
+    // reader, and truncation rolls back on any read error.
     let this = self;
+    let old_len = this.buffer.len();
+    this.buffer.resize(old_len + want_peek)?;
     loop {
-      match this.reader.read(buf) {
-        Ok(bytes) => {
-          this.buffer.extend_from_slice(&buf[..bytes])?;
-          return Ok(bytes);
+      match this.reader.read(&mut this.buffer.as_mut_slice()[old_len..]) {
+        Ok(n) => {
+          this.buffer.truncate(old_len + n);
+          buf[..n].copy_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+          return Ok(n);
         }
         Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-        Err(e) => return Err(e),
+        Err(e) => {
+          this.buffer.truncate(old_len);
+          return Err(e);
+        }
       }
     }
   }
@@ -674,30 +693,36 @@ where
   /// ```
   pub fn peek_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
     let this = &mut *self;
-    let inbuf = this.buffer.len();
 
-    let original_buf_len = buf.len();
+    // Copy the existing peek-buffer prefix into the caller's buf up
+    // front, then read successive chunks directly into the peek
+    // buffer's tail and copy them into `buf` once mirrored. This way
+    // the reader only advances for bytes already recorded for replay.
     buf.extend_from_slice(this.buffer.as_slice());
 
-    match this.reader.read_to_end(buf) {
-      Ok(read) => {
-        this
-          .buffer
-          .extend_from_slice(&buf[original_buf_len + inbuf..])?;
-        Ok(read + inbuf)
-      }
-      Err(e) => {
-        // `read_to_end` may have appended partial data before the
-        // error. Mirror those bytes into the peek buffer so the
-        // abstraction stays consistent. Leave `buf` as-is — matching
-        // std's `Read::read_to_end` contract where partial data
-        // remains in the caller's Vec on error.
-        if buf.len() > original_buf_len + inbuf {
-          this
-            .buffer
-            .extend_from_slice(&buf[original_buf_len + inbuf..])?;
+    loop {
+      let old_len = this.buffer.len();
+      this.buffer.resize(old_len + READ_CHUNK)?;
+      match this.reader.read(&mut this.buffer.as_mut_slice()[old_len..]) {
+        Ok(0) => {
+          this.buffer.truncate(old_len);
+          return Ok(this.buffer.len());
         }
-        Err(e)
+        Ok(n) => {
+          this.buffer.truncate(old_len + n);
+          buf.extend_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+          this.buffer.truncate(old_len);
+          continue;
+        }
+        Err(e) => {
+          // Partial bytes from successful prior iterations are already
+          // in both the peek buffer and `buf`; leaving them in `buf`
+          // matches std `Read::read_to_end`.
+          this.buffer.truncate(old_len);
+          return Err(e);
+        }
       }
     }
   }
@@ -710,9 +735,15 @@ where
   /// # Errors
   ///
   /// If the data in this stream is *not* valid UTF-8 then an error is
-  /// returned and `buf` is unchanged. On any other I/O error, `buf` is
-  /// also unchanged. Consumed bytes are preserved in the internal peek
-  /// buffer and can be accessed via [`get_ref`](Self::get_ref).
+  /// returned and `buf` is unchanged.
+  ///
+  /// If an I/O error occurs, any bytes the reader has already produced
+  /// remain in the internal peek buffer (accessible via
+  /// [`get_ref`](Self::get_ref)). The longest valid-UTF-8 prefix of
+  /// those bytes is appended to `buf` before the error is returned,
+  /// matching [`std::io::Read::read_to_string`]'s contract. If the
+  /// prefix is not valid UTF-8 (e.g. the reader errored mid multi-byte
+  /// sequence), `buf` is left unchanged.
   ///
   /// [`peek_to_end`]: Peek::peek_to_end
   ///
@@ -760,36 +791,45 @@ where
       }
     }
 
-    let inbuf = self.buffer.len();
-
-    // Read the remaining stream into a raw byte Vec instead of calling
-    // `read_to_string` directly. `read_to_string` restores the caller
-    // String on UTF-8 failure, which hides how many bytes the reader
-    // consumed and makes it impossible to mirror them into the peek
-    // buffer. Reading raw bytes lets us preserve them unconditionally.
-    let mut raw = Vec::new();
-    let reader_result = self.reader.read_to_end(&mut raw);
-
-    // Mirror raw bytes into the peek buffer BEFORE validating UTF-8.
-    // The reader has already consumed them; they must be replayable
-    // via future peek/read calls even if the stream is invalid UTF-8.
-    if !raw.is_empty() {
-      self.buffer.extend_from_slice(&raw)?;
-    }
-
-    // On error (either I/O or InvalidData), leave `buf` unchanged.
-    // This matches std's `Read::read_to_string` contract and the
-    // old `read_to_string`-based implementation. The consumed bytes
-    // are already in the peek buffer — the caller can inspect it
-    // via `get_ref()` if partial data is needed after an error.
-    reader_result?;
-
-    match core::str::from_utf8(self.buffer.as_slice()) {
-      Ok(s) => {
-        buf.push_str(s);
-        Ok(inbuf + raw.len())
+    // Read directly into the peek buffer so the reader only advances
+    // for bytes that are simultaneously recorded for replay. Accumulate
+    // the reader outcome and validate UTF-8 at the end — on I/O error
+    // we still want to preserve the longest valid-UTF-8 prefix.
+    let loop_result: Result<()> = loop {
+      let old_len = self.buffer.len();
+      if let Err(e) = self.buffer.resize(old_len + READ_CHUNK) {
+        break Err(e);
       }
-      Err(e) => Err(invalid_utf8_io_error(e)),
+      match self.reader.read(&mut self.buffer.as_mut_slice()[old_len..]) {
+        Ok(0) => {
+          self.buffer.truncate(old_len);
+          break Ok(());
+        }
+        Ok(n) => {
+          self.buffer.truncate(old_len + n);
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+          self.buffer.truncate(old_len);
+          continue;
+        }
+        Err(e) => {
+          self.buffer.truncate(old_len);
+          break Err(e);
+        }
+      }
+    };
+
+    match (loop_result, core::str::from_utf8(self.buffer.as_slice())) {
+      (Ok(()), Ok(s)) => {
+        buf.push_str(s);
+        Ok(self.buffer.len())
+      }
+      (Ok(()), Err(e)) => Err(invalid_utf8_io_error(e)),
+      (Err(io), Ok(s)) => {
+        buf.push_str(s);
+        Err(io)
+      }
+      (Err(io), Err(_)) => Err(io),
     }
   }
 
@@ -879,40 +919,41 @@ where
   /// # Ok(())
   /// # }
   /// ```
-  pub fn peek_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
+  pub fn peek_exact(&mut self, buf: &mut [u8]) -> Result<()> {
     let this = self;
 
-    let buf_len = buf.len();
+    let total = buf.len();
     let peek_buf_len = this.buffer.len();
 
-    if buf_len <= peek_buf_len {
-      buf.copy_from_slice(&this.buffer.as_slice()[..buf_len]);
+    if total <= peek_buf_len {
+      buf.copy_from_slice(&this.buffer.as_slice()[..total]);
       return Ok(());
     }
 
     buf[..peek_buf_len].copy_from_slice(this.buffer.as_slice());
-    {
-      let (_read, rest) = mem::take(&mut buf).split_at_mut(peek_buf_len);
-      buf = rest;
-    }
-    let mut readed = peek_buf_len;
-    while !buf.is_empty() {
+    let mut filled = peek_buf_len;
+
+    while filled < total {
+      let old_len = this.buffer.len();
+      let want = total - filled;
+      this.buffer.resize(old_len + want)?;
+
       let n = loop {
-        match this.reader.read(buf) {
+        match this.reader.read(&mut this.buffer.as_mut_slice()[old_len..]) {
           Ok(n) => break n,
           Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-          Err(e) => return Err(e),
+          Err(e) => {
+            this.buffer.truncate(old_len);
+            return Err(e);
+          }
         }
       };
-      {
-        let (read, rest) = mem::take(&mut buf).split_at_mut(n);
-        this.buffer.extend_from_slice(read)?;
-        readed += n;
-        buf = rest;
-      }
-      if n == 0 && readed != buf_len {
+      this.buffer.truncate(old_len + n);
+      if n == 0 {
         return Err(std::io::ErrorKind::UnexpectedEof.into());
       }
+      buf[filled..filled + n].copy_from_slice(&this.buffer.as_slice()[old_len..old_len + n]);
+      filled += n;
     }
 
     Ok(())

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,5 +1,5 @@
 use std::{
-  cmp, io,
+  io,
   ops::DerefMut,
   pin::Pin,
   task::{Context, Poll},
@@ -150,44 +150,40 @@ impl<R: AsyncRead, B: Buffer> AsyncRead for AsyncPeekable<R, B> {
     if buffer_len > 0 {
       let available = buf.remaining();
 
-      return match available.cmp(&buffer_len) {
-        cmp::Ordering::Greater => {
-          // Track the original filled length so we can roll back on
-          // error or pending — `put_slice` advances filled and otherwise
-          // would leave the caller's buffer corrupted.
-          let orig_filled = buf.filled().len();
-          buf.put_slice(this.buffer.as_slice());
-
-          match this.reader.poll_read(cx, buf) {
-            Poll::Ready(Ok(())) => {
-              this.buffer.clear();
-              Poll::Ready(Ok(()))
-            }
-            Poll::Ready(Err(e)) => {
-              // Roll back the put_slice so the caller's buf is unchanged.
-              // The peek buffer is preserved for a retry.
-              buf.set_filled(orig_filled);
-              Poll::Ready(Err(e))
-            }
-            Poll::Pending => {
-              // The inner reader has no more data right now, but we did
-              // serve `buffer_len` bytes from the peek buffer. Return a
-              // partial-Ready (a valid `AsyncRead` outcome) and clear
-              // the peek buffer so the bytes aren't returned again.
-              this.buffer.clear();
-              Poll::Ready(Ok(()))
-            }
-          }
-        }
-        cmp::Ordering::Equal => {
-          buf.put_slice(this.buffer.as_slice());
+      if available < buffer_len {
+        buf.put_slice(&this.buffer.as_slice()[..available]);
+        this.buffer.consume(..available);
+        return Poll::Ready(Ok(()));
+      } else if available == buffer_len {
+        buf.put_slice(this.buffer.as_slice());
+        this.buffer.clear();
+        return Poll::Ready(Ok(()));
+      }
+      // available > buffer_len — flush the peek buffer into caller's
+      // ReadBuf, then top up from the inner reader.
+      buf.put_slice(this.buffer.as_slice());
+      return match this.reader.poll_read(cx, buf) {
+        Poll::Ready(Ok(())) => {
           this.buffer.clear();
-          return Poll::Ready(Ok(()));
+          Poll::Ready(Ok(()))
         }
-        cmp::Ordering::Less => {
-          buf.put_slice(&this.buffer.as_slice()[..available]);
-          this.buffer.consume(..available);
-          return Poll::Ready(Ok(()));
+        Poll::Ready(Err(_)) => {
+          // Inner errored after we'd already served the peek buffer
+          // via put_slice. `AsyncRead` contract forbids returning
+          // Err after writing bytes, so surface the partial success;
+          // the caller's next poll_read will delegate to the inner
+          // reader (peek buffer now empty) and see the persistent
+          // error on the next call.
+          this.buffer.clear();
+          Poll::Ready(Ok(()))
+        }
+        Poll::Pending => {
+          // The inner reader has no more data right now, but we did
+          // serve `buffer_len` bytes from the peek buffer. Return a
+          // partial-Ready (a valid `AsyncRead` outcome) and clear
+          // the peek buffer so the bytes aren't returned again.
+          this.buffer.clear();
+          Poll::Ready(Ok(()))
         }
       };
     }
@@ -223,7 +219,7 @@ impl<R: AsyncRead, B: Buffer> AsyncPeek for AsyncPeekable<R, B> {
     cx: &mut Context<'_>,
     buf: &mut ReadBuf<'_>,
   ) -> Poll<io::Result<()>> {
-    let this = self.project();
+    let mut this = self.project();
     let buffer_len = this.buffer.len();
     let available = buf.remaining();
 
@@ -239,32 +235,44 @@ impl<R: AsyncRead, B: Buffer> AsyncPeek for AsyncPeekable<R, B> {
 
     // Top up from the reader. Read directly into the peek buffer's
     // tail via a ReadBuf so the reader only advances for bytes we
-    // simultaneously record for replay.
+    // simultaneously record for replay. Retry on `Interrupted` and
+    // convert `WouldBlock` to `Pending` per peek semantics (mirroring
+    // the futures-util `AsyncPeek` contract, which explicitly forbids
+    // either being surfaced to the caller).
     let want = available - buffer_len;
     let old_len = buffer_len;
     this.buffer.resize(old_len + want)?;
-    let mut tail = ReadBuf::new(&mut this.buffer.as_mut_slice()[old_len..]);
-    match this.reader.poll_read(cx, &mut tail) {
-      Poll::Ready(Ok(())) => {
-        let n = tail.filled().len();
-        this.buffer.truncate(old_len + n);
-        // Copy existing prefix + newly-read bytes to caller's buf.
-        buf.put_slice(&this.buffer.as_slice()[..old_len + n]);
-        Poll::Ready(Ok(()))
-      }
-      Poll::Ready(Err(e)) => {
-        this.buffer.truncate(old_len);
-        Poll::Ready(Err(e))
-      }
-      Poll::Pending => {
-        this.buffer.truncate(old_len);
-        if buffer_len > 0 {
-          // Hand the caller the prefix we already have — the data
-          // is still in this.buffer so later peeks see it again.
-          buf.put_slice(this.buffer.as_slice());
-          Poll::Ready(Ok(()))
-        } else {
-          Poll::Pending
+    loop {
+      let mut tail = ReadBuf::new(&mut this.buffer.as_mut_slice()[old_len..]);
+      match this.reader.as_mut().poll_read(cx, &mut tail) {
+        Poll::Ready(Ok(())) => {
+          let n = tail.filled().len();
+          this.buffer.truncate(old_len + n);
+          buf.put_slice(&this.buffer.as_slice()[..old_len + n]);
+          return Poll::Ready(Ok(()));
+        }
+        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => continue,
+        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::WouldBlock => {
+          this.buffer.truncate(old_len);
+          return if buffer_len > 0 {
+            buf.put_slice(this.buffer.as_slice());
+            Poll::Ready(Ok(()))
+          } else {
+            Poll::Pending
+          };
+        }
+        Poll::Ready(Err(e)) => {
+          this.buffer.truncate(old_len);
+          return Poll::Ready(Err(e));
+        }
+        Poll::Pending => {
+          this.buffer.truncate(old_len);
+          return if buffer_len > 0 {
+            buf.put_slice(this.buffer.as_slice());
+            Poll::Ready(Ok(()))
+          } else {
+            Poll::Pending
+          };
         }
       }
     }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -225,54 +225,47 @@ impl<R: AsyncRead, B: Buffer> AsyncPeek for AsyncPeekable<R, B> {
   ) -> Poll<io::Result<()>> {
     let this = self.project();
     let buffer_len = this.buffer.len();
+    let available = buf.remaining();
 
-    // Check if the buffer has enough data to fill `buf`
-    if buffer_len > 0 {
-      let available = buf.remaining();
-      if available > buffer_len {
-        // Not enough data in the buffer; try to peek more from the inner
-        // reader. Track `orig_filled` so we can roll back on error.
-        let orig_filled = buf.filled().len();
-        buf.put_slice(this.buffer.as_slice());
-        let cur = buf.filled().len();
-        match this.reader.poll_read(cx, buf) {
-          Poll::Ready(Ok(())) => {
-            let filled = buf.filled();
-            let read = filled.len() - cur;
-            this.buffer.extend_from_slice(&filled[cur..cur + read])?;
-            Poll::Ready(Ok(()))
-          }
-          Poll::Ready(Err(e)) => {
-            // Roll back the put_slice so the caller's buf is unchanged.
-            buf.set_filled(orig_filled);
-            Poll::Ready(Err(e))
-          }
-          Poll::Pending => {
-            // The inner reader has no more data right now, but we have
-            // already placed `buffer_len` bytes from the peek buffer
-            // into `buf`. Return a partial peek as `Ready(Ok(()))` —
-            // the data is still in `this.buffer` so subsequent peeks
-            // see it again. (Do NOT put_slice a second time.)
-            Poll::Ready(Ok(()))
-          }
-        }
-      } else {
-        // Enough data in the buffer, copy it to `buf`
-        buf.put_slice(&this.buffer.as_slice()[..available]);
+    if available == 0 {
+      return Poll::Ready(Ok(()));
+    }
+
+    // Fast path: the existing peek buffer already covers the request.
+    if buffer_len >= available {
+      buf.put_slice(&this.buffer.as_slice()[..available]);
+      return Poll::Ready(Ok(()));
+    }
+
+    // Top up from the reader. Read directly into the peek buffer's
+    // tail via a ReadBuf so the reader only advances for bytes we
+    // simultaneously record for replay.
+    let want = available - buffer_len;
+    let old_len = buffer_len;
+    this.buffer.resize(old_len + want)?;
+    let mut tail = ReadBuf::new(&mut this.buffer.as_mut_slice()[old_len..]);
+    match this.reader.poll_read(cx, &mut tail) {
+      Poll::Ready(Ok(())) => {
+        let n = tail.filled().len();
+        this.buffer.truncate(old_len + n);
+        // Copy existing prefix + newly-read bytes to caller's buf.
+        buf.put_slice(&this.buffer.as_slice()[..old_len + n]);
         Poll::Ready(Ok(()))
       }
-    } else {
-      // No data in the buffer, try to peek directly into `buf`
-      let cur = buf.filled().len();
-      match this.reader.poll_read(cx, buf) {
-        Poll::Ready(Ok(())) => {
-          let filled = buf.filled();
-          let read = filled.len() - cur;
-          this.buffer.extend_from_slice(&filled[cur..cur + read])?;
+      Poll::Ready(Err(e)) => {
+        this.buffer.truncate(old_len);
+        Poll::Ready(Err(e))
+      }
+      Poll::Pending => {
+        this.buffer.truncate(old_len);
+        if buffer_len > 0 {
+          // Hand the caller the prefix we already have — the data
+          // is still in this.buffer so later peeks see it again.
+          buf.put_slice(this.buffer.as_slice());
           Poll::Ready(Ok(()))
+        } else {
+          Poll::Pending
         }
-        Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-        Poll::Pending => Poll::Pending,
       }
     }
   }

--- a/src/tokio/peek_exact.rs
+++ b/src/tokio/peek_exact.rs
@@ -66,27 +66,38 @@ where
       }
     }
 
-    // Read from the inner reader into the unfilled portion.
+    // Read from the inner reader directly into the peek buffer's tail
+    // so the reader only advances for bytes recorded for replay.
     while *me.filled < total {
-      let mut read_buf = tokio::io::ReadBuf::new(&mut me.buf[*me.filled..]);
-      match Pin::new(&mut me.peekable.reader).poll_read(cx, &mut read_buf) {
+      let old_len = me.peekable.buffer.len();
+      let want = total - *me.filled;
+      me.peekable.buffer.resize(old_len + want)?;
+
+      let mut tail = tokio::io::ReadBuf::new(&mut me.peekable.buffer.as_mut_slice()[old_len..]);
+      match Pin::new(&mut me.peekable.reader).poll_read(cx, &mut tail) {
         Poll::Ready(Ok(())) => {}
-        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => continue,
-        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-        Poll::Pending => return Poll::Pending,
+        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+          me.peekable.buffer.truncate(old_len);
+          continue;
+        }
+        Poll::Ready(Err(e)) => {
+          me.peekable.buffer.truncate(old_len);
+          return Poll::Ready(Err(e));
+        }
+        Poll::Pending => {
+          me.peekable.buffer.truncate(old_len);
+          return Poll::Pending;
+        }
       }
-      let n = read_buf.filled().len();
+      let n = tail.filled().len();
+      me.peekable.buffer.truncate(old_len + n);
 
       if n == 0 {
         return Poll::Ready(Err(eof()));
       }
 
-      // TODO(al8n): same fallible-Buffer concern as peek_to_end/
-      // peek_to_string — if extend_from_slice fails, the bytes are
-      // in the caller's buf but not mirrored to the peek buffer.
-      me.peekable
-        .buffer
-        .extend_from_slice(&me.buf[*me.filled..*me.filled + n])?;
+      me.buf[*me.filled..*me.filled + n]
+        .copy_from_slice(&me.peekable.buffer.as_slice()[old_len..old_len + n]);
       *me.filled += n;
     }
 

--- a/src/tokio/peek_to_end.rs
+++ b/src/tokio/peek_to_end.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use super::{AsyncPeekable, Buffer, DefaultBuffer};
-use crate::READ_CHUNK;
+use crate::grow_peek_buffer;
 
 pin_project! {
   /// Peek to end
@@ -58,8 +58,9 @@ where
 
     loop {
       let old_len = me.peekable.buffer.len();
-      me.peekable.buffer.resize(old_len + READ_CHUNK)?;
-      let mut tail = tokio::io::ReadBuf::new(&mut me.peekable.buffer.as_mut_slice()[old_len..]);
+      let growth = grow_peek_buffer(&mut me.peekable.buffer)?;
+      let mut tail =
+        tokio::io::ReadBuf::new(&mut me.peekable.buffer.as_mut_slice()[old_len..old_len + growth]);
       match Pin::new(&mut me.peekable.reader).poll_read(cx, &mut tail) {
         Poll::Ready(Ok(())) => {
           let n = tail.filled().len();

--- a/src/tokio/peek_to_end.rs
+++ b/src/tokio/peek_to_end.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use super::{AsyncPeekable, Buffer, DefaultBuffer};
-use crate::StagingBuf;
+use crate::READ_CHUNK;
 
 pin_project! {
   /// Peek to end
@@ -19,9 +19,7 @@ pin_project! {
   pub struct PeekToEnd<'a, R, B = DefaultBuffer> {
     peekable: &'a mut AsyncPeekable<R, B>,
     buf: &'a mut Vec<u8>,
-    initial_peek_len: usize,
-    reader_data_start: Option<usize>,
-    staging: StagingBuf,
+    prefix_copied: bool,
     #[pin]
     _pin: PhantomPinned,
   }
@@ -35,13 +33,10 @@ where
   R: AsyncRead + Unpin,
   B: Buffer,
 {
-  let initial_peek_len = peekable.buffer.len();
   PeekToEnd {
     peekable,
     buf: buffer,
-    initial_peek_len,
-    reader_data_start: None,
-    staging: crate::new_staging_buf(),
+    prefix_copied: false,
     _pin: PhantomPinned,
   }
 }
@@ -55,42 +50,42 @@ where
 
   fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
     let me = self.project();
-    let inbuf = *me.initial_peek_len;
 
-    let reader_start = match *me.reader_data_start {
-      Some(pos) => pos,
-      None => {
-        me.buf.extend_from_slice(me.peekable.buffer.as_slice());
-        let pos = me.buf.len();
-        *me.reader_data_start = Some(pos);
-        pos
-      }
-    };
+    if !*me.prefix_copied {
+      me.buf.extend_from_slice(me.peekable.buffer.as_slice());
+      *me.prefix_copied = true;
+    }
 
     loop {
-      let mut read_buf = tokio::io::ReadBuf::new(me.staging);
-      match Pin::new(&mut me.peekable.reader).poll_read(cx, &mut read_buf) {
+      let old_len = me.peekable.buffer.len();
+      me.peekable.buffer.resize(old_len + READ_CHUNK)?;
+      let mut tail = tokio::io::ReadBuf::new(&mut me.peekable.buffer.as_mut_slice()[old_len..]);
+      match Pin::new(&mut me.peekable.reader).poll_read(cx, &mut tail) {
         Poll::Ready(Ok(())) => {
-          let filled = read_buf.filled();
-          let n = filled.len();
+          let n = tail.filled().len();
           if n == 0 {
-            return Poll::Ready(Ok(inbuf + (me.buf.len() - reader_start)));
+            me.peekable.buffer.truncate(old_len);
+            return Poll::Ready(Ok(me.peekable.buffer.len()));
           }
-          // TODO(al8n): if extend_from_slice fails, the peek buffer
-          // won't have these bytes — see future/peek_to_end.rs.
-          // At least give the caller the data in buf (matching
-          // read_to_end's partial-data-on-error contract).
-          if let Err(e) = me.peekable.buffer.extend_from_slice(filled) {
-            me.buf.extend_from_slice(filled);
-            return Poll::Ready(Err(e));
-          }
-          me.buf.extend_from_slice(filled);
+          me.peekable.buffer.truncate(old_len + n);
+          me.buf
+            .extend_from_slice(&me.peekable.buffer.as_slice()[old_len..old_len + n]);
         }
-        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => continue,
-        // Leave partial data in buf — matches std/tokio's
-        // read_to_end contract.
-        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-        Poll::Pending => return Poll::Pending,
+        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+          me.peekable.buffer.truncate(old_len);
+          continue;
+        }
+        Poll::Ready(Err(e)) => {
+          // Partial data already mirrored into both the peek buffer
+          // (prior iterations) and `buf`. Leaving it in `buf` matches
+          // std/tokio's read_to_end contract.
+          me.peekable.buffer.truncate(old_len);
+          return Poll::Ready(Err(e));
+        }
+        Poll::Pending => {
+          me.peekable.buffer.truncate(old_len);
+          return Poll::Pending;
+        }
       }
     }
   }

--- a/src/tokio/peek_to_string.rs
+++ b/src/tokio/peek_to_string.rs
@@ -1,5 +1,5 @@
 use super::{AsyncPeekable, Buffer, DefaultBuffer};
-use crate::READ_CHUNK;
+use crate::grow_peek_buffer;
 use ::tokio::io::AsyncRead;
 
 use pin_project_lite::pin_project;
@@ -64,11 +64,12 @@ where
     // preserves the longest valid-UTF-8 prefix of consumed bytes.
     loop {
       let old_len = me.peekable.buffer.len();
-      let loop_result: io::Result<()> =
-        if let Err(e) = me.peekable.buffer.resize(old_len + READ_CHUNK) {
-          Err(e)
-        } else {
-          let mut tail = tokio::io::ReadBuf::new(&mut me.peekable.buffer.as_mut_slice()[old_len..]);
+      let loop_result: io::Result<()> = match grow_peek_buffer(&mut me.peekable.buffer) {
+        Err(e) => Err(e),
+        Ok(growth) => {
+          let mut tail = tokio::io::ReadBuf::new(
+            &mut me.peekable.buffer.as_mut_slice()[old_len..old_len + growth],
+          );
           match Pin::new(&mut me.peekable.reader).poll_read(cx, &mut tail) {
             Poll::Ready(Ok(())) => {
               let n = tail.filled().len();
@@ -93,7 +94,8 @@ where
               return Poll::Pending;
             }
           }
-        };
+        }
+      };
 
       return Poll::Ready(
         match (
@@ -109,7 +111,20 @@ where
             me.output.push_str(s);
             Err(io)
           }
-          (Err(io), Err(_)) => Err(io),
+          (Err(io), Err(utf8_err)) => {
+            // Preserve the longest valid-UTF-8 prefix of the
+            // consumed bytes; bytes after `valid_up_to()` are either
+            // invalid or an incomplete multi-byte sequence and are
+            // dropped from `output` (still accessible via
+            // `get_ref()`).
+            let vut = utf8_err.valid_up_to();
+            if vut != 0 {
+              let s = core::str::from_utf8(&me.peekable.buffer.as_slice()[..vut])
+                .expect("valid_up_to() must point to a valid UTF-8 prefix");
+              me.output.push_str(s);
+            }
+            Err(io)
+          }
         },
       );
     }

--- a/src/tokio/peek_to_string.rs
+++ b/src/tokio/peek_to_string.rs
@@ -1,5 +1,5 @@
 use super::{AsyncPeekable, Buffer, DefaultBuffer};
-use crate::StagingBuf;
+use crate::READ_CHUNK;
 use ::tokio::io::AsyncRead;
 
 use pin_project_lite::pin_project;
@@ -19,7 +19,6 @@ pin_project! {
     peekable: &'a mut AsyncPeekable<R, B>,
     output: &'a mut String,
     started: bool,
-    staging: StagingBuf,
     #[pin]
     _pin: PhantomPinned,
   }
@@ -37,7 +36,6 @@ where
     peekable,
     output: string,
     started: false,
-    staging: crate::new_staging_buf(),
     _pin: PhantomPinned,
   }
 }
@@ -61,32 +59,59 @@ where
       *me.started = true;
     }
 
+    // Read into the peek buffer's tail and validate UTF-8 only after
+    // the reader signals EOF or an error — that way an I/O error still
+    // preserves the longest valid-UTF-8 prefix of consumed bytes.
     loop {
-      let mut read_buf = tokio::io::ReadBuf::new(me.staging);
-      match Pin::new(&mut me.peekable.reader).poll_read(cx, &mut read_buf) {
-        Poll::Ready(Ok(())) => {
-          let n = read_buf.filled().len();
-          if n == 0 {
-            let s = match core::str::from_utf8(me.peekable.buffer.as_slice()) {
-              Ok(s) => s,
-              Err(e) => return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidData, e))),
-            };
-            me.output.push_str(s);
-            return Poll::Ready(Ok(me.peekable.buffer.len()));
+      let old_len = me.peekable.buffer.len();
+      let loop_result: io::Result<()> =
+        if let Err(e) = me.peekable.buffer.resize(old_len + READ_CHUNK) {
+          Err(e)
+        } else {
+          let mut tail = tokio::io::ReadBuf::new(&mut me.peekable.buffer.as_mut_slice()[old_len..]);
+          match Pin::new(&mut me.peekable.reader).poll_read(cx, &mut tail) {
+            Poll::Ready(Ok(())) => {
+              let n = tail.filled().len();
+              if n == 0 {
+                me.peekable.buffer.truncate(old_len);
+                Ok(())
+              } else {
+                me.peekable.buffer.truncate(old_len + n);
+                continue;
+              }
+            }
+            Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+              me.peekable.buffer.truncate(old_len);
+              continue;
+            }
+            Poll::Ready(Err(e)) => {
+              me.peekable.buffer.truncate(old_len);
+              Err(e)
+            }
+            Poll::Pending => {
+              me.peekable.buffer.truncate(old_len);
+              return Poll::Pending;
+            }
           }
-          // TODO(al8n): if `extend_from_slice` fails here, the bytes in
-          // `read_buf` are lost — the reader already consumed them
-          // but they can't be stored in the peek buffer. A future
-          // improvement could read directly into the peek buffer's
-          // tail (via `resize` + `poll_read` into
-          // `buffer.as_mut_slice()[old_len..]`) to eliminate this
-          // window.
-          me.peekable.buffer.extend_from_slice(read_buf.filled())?;
-        }
-        Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => continue,
-        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-        Poll::Pending => return Poll::Pending,
-      }
+        };
+
+      return Poll::Ready(
+        match (
+          loop_result,
+          core::str::from_utf8(me.peekable.buffer.as_slice()),
+        ) {
+          (Ok(()), Ok(s)) => {
+            me.output.push_str(s);
+            Ok(me.peekable.buffer.len())
+          }
+          (Ok(()), Err(e)) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+          (Err(io), Ok(s)) => {
+            me.output.push_str(s);
+            Err(io)
+          }
+          (Err(io), Err(_)) => Err(io),
+        },
+      );
     }
   }
 }

--- a/tests/futures_io.rs
+++ b/tests/futures_io.rs
@@ -776,3 +776,207 @@ fn peek_to_end_keeps_partial_data_on_error() {
     assert!(out.len() > 8);
   });
 }
+
+// ------------------------------------------------------------------
+// Regression tests for:
+//   Finding 1: peek_to_string must preserve partial valid-UTF-8 in
+//              the caller's String on ordinary I/O errors.
+//   Finding 2: a fallible Buffer must not leave the inner reader
+//              advanced past what the peek buffer can replay.
+// ------------------------------------------------------------------
+
+use peekable::buffer::Buffer;
+
+#[derive(Debug, Default)]
+struct BoundedBuffer<const CAP: usize> {
+  inner: Vec<u8>,
+}
+
+impl<const CAP: usize> AsRef<[u8]> for BoundedBuffer<CAP> {
+  fn as_ref(&self) -> &[u8] {
+    &self.inner
+  }
+}
+
+impl<const CAP: usize> Buffer for BoundedBuffer<CAP> {
+  fn new() -> Self {
+    Self { inner: Vec::new() }
+  }
+  fn with_capacity(_: usize) -> Self {
+    Self { inner: Vec::new() }
+  }
+  fn consume(&mut self, rng: std::ops::RangeTo<usize>) {
+    self.inner.drain(rng);
+  }
+  fn clear(&mut self) {
+    self.inner.clear();
+  }
+  fn resize(&mut self, len: usize) -> io::Result<()> {
+    if len > CAP {
+      return Err(io::Error::new(io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+    }
+    self.inner.resize(len, 0);
+    Ok(())
+  }
+  fn truncate(&mut self, len: usize) {
+    self.inner.truncate(len);
+  }
+  fn extend_from_slice(&mut self, other: &[u8]) -> io::Result<()> {
+    if self.inner.len() + other.len() > CAP {
+      return Err(io::Error::new(io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+    }
+    self.inner.extend_from_slice(other);
+    Ok(())
+  }
+  fn as_slice(&self) -> &[u8] {
+    &self.inner
+  }
+  fn as_mut_slice(&mut self) -> &mut [u8] {
+    &mut self.inner
+  }
+  fn len(&self) -> usize {
+    self.inner.len()
+  }
+  fn is_empty(&self) -> bool {
+    self.inner.is_empty()
+  }
+  fn capacity(&self) -> usize {
+    CAP
+  }
+}
+
+struct AsyncErroringReader {
+  data: Cursor<Vec<u8>>,
+  error_after: usize,
+  served: usize,
+  kind: ErrorKind,
+}
+
+impl AsyncErroringReader {
+  fn new(data: Vec<u8>, error_after: usize, kind: ErrorKind) -> Self {
+    Self {
+      data: Cursor::new(data),
+      error_after,
+      served: 0,
+      kind,
+    }
+  }
+}
+
+impl AsyncRead for AsyncErroringReader {
+  fn poll_read(
+    self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+    buf: &mut [u8],
+  ) -> Poll<io::Result<usize>> {
+    let me = self.get_mut();
+    if me.served >= me.error_after {
+      return Poll::Ready(Err(io::Error::new(me.kind, "synthetic")));
+    }
+    let cap = (me.error_after - me.served).min(buf.len());
+    match Pin::new(&mut me.data).poll_read(cx, &mut buf[..cap]) {
+      Poll::Ready(Ok(n)) => {
+        me.served += n;
+        Poll::Ready(Ok(n))
+      }
+      other => other,
+    }
+  }
+}
+
+#[test]
+fn async_peek_does_not_advance_reader_when_buffer_extend_fails() {
+  futures::executor::block_on(async {
+    let reader = Cursor::new(vec![1u8, 2, 3, 4]);
+    let mut p: AsyncPeekable<_, BoundedBuffer<0>> = reader.peekable_with_buffer();
+    let mut buf = [0u8; 2];
+    let err = p.peek(&mut buf).await.expect_err("must fail");
+    assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+    let (_, reader) = p.get_mut();
+    let mut out = Vec::new();
+    reader.read_to_end(&mut out).await.unwrap();
+    assert_eq!(out, [1, 2, 3, 4]);
+  });
+}
+
+#[test]
+fn async_peek_exact_does_not_advance_reader_when_buffer_extend_fails() {
+  futures::executor::block_on(async {
+    let reader = Cursor::new(vec![1u8, 2, 3, 4]);
+    let mut p: AsyncPeekable<_, BoundedBuffer<0>> = reader.peekable_with_buffer();
+    let mut buf = [0u8; 4];
+    let err = p.peek_exact(&mut buf).await.expect_err("must fail");
+    assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+    let (peek_slice, reader) = p.get_mut();
+    let have = peek_slice.len();
+    let mut out = Vec::new();
+    reader.read_to_end(&mut out).await.unwrap();
+    assert_eq!(have + out.len(), 4);
+  });
+}
+
+#[test]
+fn async_peek_to_end_preserves_partial_data_on_io_error() {
+  futures::executor::block_on(async {
+    let reader = AsyncErroringReader::new(b"hello".to_vec(), 3, ErrorKind::ConnectionReset);
+    let mut p = reader.peekable();
+    let mut out = Vec::new();
+    let err = p.peek_to_end(&mut out).await.expect_err("io error");
+    assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+    assert_eq!(out, b"hel");
+  });
+}
+
+#[test]
+fn async_peek_to_end_does_not_desync_on_buffer_error() {
+  futures::executor::block_on(async {
+    let reader = Cursor::new(b"abcdef".to_vec());
+    let mut p: AsyncPeekable<_, BoundedBuffer<2>> = reader.peekable_with_buffer();
+    let mut scratch = [0u8; 2];
+    assert_eq!(p.peek(&mut scratch).await.unwrap(), 2);
+    let mut out = Vec::new();
+    let err = p.peek_to_end(&mut out).await.expect_err("must fail");
+    assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+    let (peek_slice, reader) = p.get_mut();
+    let have = peek_slice.len();
+    let mut tail = Vec::new();
+    reader.read_to_end(&mut tail).await.unwrap();
+    assert_eq!(have + tail.len(), 6);
+  });
+}
+
+#[test]
+fn async_peek_to_string_preserves_partial_valid_utf8_on_io_error() {
+  futures::executor::block_on(async {
+    let reader = AsyncErroringReader::new(b"hello".to_vec(), 3, ErrorKind::ConnectionReset);
+    let mut p = reader.peekable();
+    let mut out = String::new();
+    let err = p.peek_to_string(&mut out).await.expect_err("io error");
+    assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+    assert_eq!(out, "hel");
+  });
+}
+
+#[test]
+fn async_peek_to_string_leaves_buf_unchanged_when_partial_bytes_are_invalid_utf8() {
+  futures::executor::block_on(async {
+    let reader = AsyncErroringReader::new(vec![0xE2, 0x82, 0xAC], 2, ErrorKind::ConnectionReset);
+    let mut p = reader.peekable();
+    let mut out = String::from("prefix:");
+    let err = p.peek_to_string(&mut out).await.expect_err("io error");
+    assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+    assert_eq!(out, "prefix:");
+  });
+}
+
+#[test]
+fn async_peek_to_string_returns_invalid_data_for_clean_invalid_utf8() {
+  futures::executor::block_on(async {
+    let reader = Cursor::new(vec![0xFF, 0xFE]);
+    let mut p = reader.peekable();
+    let mut out = String::from("prefix:");
+    let err = p.peek_to_string(&mut out).await.expect_err("must fail");
+    assert_eq!(err.kind(), ErrorKind::InvalidData);
+    assert_eq!(out, "prefix:");
+  });
+}

--- a/tests/futures_io.rs
+++ b/tests/futures_io.rs
@@ -813,7 +813,10 @@ impl<const CAP: usize> Buffer for BoundedBuffer<CAP> {
   }
   fn resize(&mut self, len: usize) -> io::Result<()> {
     if len > CAP {
-      return Err(io::Error::new(io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+      return Err(io::Error::new(
+        io::ErrorKind::OutOfMemory,
+        "BoundedBuffer cap",
+      ));
     }
     self.inner.resize(len, 0);
     Ok(())
@@ -823,7 +826,10 @@ impl<const CAP: usize> Buffer for BoundedBuffer<CAP> {
   }
   fn extend_from_slice(&mut self, other: &[u8]) -> io::Result<()> {
     if self.inner.len() + other.len() > CAP {
-      return Err(io::Error::new(io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+      return Err(io::Error::new(
+        io::ErrorKind::OutOfMemory,
+        "BoundedBuffer cap",
+      ));
     }
     self.inner.extend_from_slice(other);
     Ok(())

--- a/tests/futures_io.rs
+++ b/tests/futures_io.rs
@@ -28,6 +28,7 @@ use peekable::future::{AsyncPeek, AsyncPeekExt, AsyncPeekable};
 enum Action {
   Pending,
   Interrupted,
+  WouldBlock,
   OtherErr,
   ReadFromInner,
 }
@@ -62,6 +63,7 @@ impl AsyncRead for FlakyReader {
         Poll::Pending
       }
       Action::Interrupted => Poll::Ready(Err(io::Error::new(ErrorKind::Interrupted, "x"))),
+      Action::WouldBlock => Poll::Ready(Err(io::Error::new(ErrorKind::WouldBlock, "wb"))),
       Action::OtherErr => Poll::Ready(Err(io::Error::new(ErrorKind::Other, "boom"))),
       Action::ReadFromInner => {
         let inner = std::pin::Pin::new(&mut self.inner);
@@ -514,14 +516,24 @@ fn poll_peek_no_buffer_inner_error() {
 
 #[test]
 fn read_when_request_greater_than_buffer_error() {
+  // Peek buffer has 2 bytes; read(5) triggers an inner error on the
+  // top-up. Updated behavior: the 2 buffered bytes are delivered
+  // (can't return Err after writing bytes per AsyncRead contract),
+  // peek buffer is cleared, and the inner error surfaces on the next
+  // read() which delegates directly to the inner reader.
   futures::executor::block_on(async {
     let r = FlakyReader::new(
       b"hello".to_vec(),
-      vec![Action::ReadFromInner, Action::OtherErr],
+      vec![Action::ReadFromInner, Action::OtherErr, Action::OtherErr],
     );
     let mut p = AsyncPeekable::new(r);
     p.peek(&mut [0u8; 2]).await.unwrap();
+
     let mut out = [0u8; 5];
+    let n = p.read(&mut out).await.unwrap();
+    assert_eq!(n, 2);
+    assert_eq!(&out[..2], b"he");
+
     let err = p.read(&mut out).await.unwrap_err();
     assert_eq!(err.kind(), ErrorKind::Other);
   });
@@ -984,5 +996,234 @@ fn async_peek_to_string_returns_invalid_data_for_clean_invalid_utf8() {
     let err = p.peek_to_string(&mut out).await.expect_err("must fail");
     assert_eq!(err.kind(), ErrorKind::InvalidData);
     assert_eq!(out, "prefix:");
+  });
+}
+
+// ---- Coverage for Interrupted / Pending / Err paths -----------------
+
+#[test]
+fn peek_exact_retries_on_interrupted_async() {
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(
+      b"hello".to_vec(),
+      vec![Action::Interrupted, Action::ReadFromInner],
+    );
+    let mut p = AsyncPeekable::new(r);
+    let mut b = [0u8; 5];
+    p.peek_exact(&mut b).await.unwrap();
+    assert_eq!(&b, b"hello");
+  });
+}
+
+#[test]
+fn peek_exact_propagates_error_async() {
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(b"hello".to_vec(), vec![Action::OtherErr]);
+    let mut p = AsyncPeekable::new(r);
+    let mut b = [0u8; 5];
+    let err = p.peek_exact(&mut b).await.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Other);
+  });
+}
+
+#[test]
+fn peek_exact_survives_pending_boundary_async() {
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(
+      b"hello".to_vec(),
+      vec![Action::Pending, Action::ReadFromInner],
+    );
+    let mut p = AsyncPeekable::new(r);
+    let mut b = [0u8; 5];
+    p.peek_exact(&mut b).await.unwrap();
+    assert_eq!(&b, b"hello");
+  });
+}
+
+#[test]
+fn peek_to_end_retries_on_interrupted_async() {
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(
+      b"hello".to_vec(),
+      vec![
+        Action::ReadFromInner,
+        Action::Interrupted,
+        Action::ReadFromInner,
+      ],
+    );
+    let mut p = AsyncPeekable::new(r);
+    let mut out = Vec::new();
+    let n = p.peek_to_end(&mut out).await.unwrap();
+    assert_eq!(out, b"hello");
+    assert_eq!(n, 5);
+  });
+}
+
+#[test]
+fn peek_to_end_survives_pending_async() {
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(
+      b"hello".to_vec(),
+      vec![
+        Action::ReadFromInner,
+        Action::Pending,
+        Action::ReadFromInner,
+      ],
+    );
+    let mut p = AsyncPeekable::new(r);
+    let mut out = Vec::new();
+    let n = p.peek_to_end(&mut out).await.unwrap();
+    assert_eq!(out, b"hello");
+    assert_eq!(n, 5);
+  });
+}
+
+#[test]
+fn peek_to_string_retries_on_interrupted_async() {
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(
+      b"hello".to_vec(),
+      vec![
+        Action::ReadFromInner,
+        Action::Interrupted,
+        Action::ReadFromInner,
+      ],
+    );
+    let mut p = AsyncPeekable::new(r);
+    let mut out = String::new();
+    let n = p.peek_to_string(&mut out).await.unwrap();
+    assert_eq!(out, "hello");
+    assert_eq!(n, 5);
+  });
+}
+
+#[test]
+fn peek_to_string_survives_pending_async() {
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(
+      b"hello".to_vec(),
+      vec![
+        Action::ReadFromInner,
+        Action::Pending,
+        Action::ReadFromInner,
+      ],
+    );
+    let mut p = AsyncPeekable::new(r);
+    let mut out = String::new();
+    let n = p.peek_to_string(&mut out).await.unwrap();
+    assert_eq!(out, "hello");
+    assert_eq!(n, 5);
+  });
+}
+
+#[test]
+fn peek_to_string_buffer_resize_fails_preserves_partial_utf8_async() {
+  futures::executor::block_on(async {
+    let reader = Cursor::new(b"hello".to_vec());
+    let mut p: AsyncPeekable<_, BoundedBuffer<2>> = reader.peekable_with_capacity_and_buffer(2);
+    let mut scratch = [0u8; 2];
+    assert_eq!(p.peek(&mut scratch).await.unwrap(), 2);
+    let mut out = String::from("prefix:");
+    let err = p.peek_to_string(&mut out).await.expect_err("must fail");
+    assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+    assert_eq!(out, "prefix:he");
+  });
+}
+
+#[test]
+fn peek_to_end_succeeds_with_small_cap_when_data_fits_async() {
+  futures::executor::block_on(async {
+    let reader = Cursor::new(b"0123456789".to_vec());
+    let mut p: AsyncPeekable<_, BoundedBuffer<100>> = reader.peekable_with_buffer();
+    let mut out = Vec::new();
+    let n = p.peek_to_end(&mut out).await.unwrap();
+    assert_eq!(n, 10);
+    assert_eq!(out, b"0123456789");
+  });
+}
+
+#[test]
+fn peek_to_string_succeeds_with_small_cap_when_data_fits_async() {
+  futures::executor::block_on(async {
+    let reader = Cursor::new(b"hello".to_vec());
+    let mut p: AsyncPeekable<_, BoundedBuffer<100>> = reader.peekable_with_buffer();
+    let mut out = String::new();
+    let n = p.peek_to_string(&mut out).await.unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(out, "hello");
+  });
+}
+
+#[test]
+fn peek_to_string_preserves_valid_prefix_before_incomplete_utf8_on_io_error_async() {
+  futures::executor::block_on(async {
+    let reader = AsyncErroringReader::new(vec![b'h', 0xE2, 0x82], 3, ErrorKind::ConnectionReset);
+    let mut p = reader.peekable();
+    let mut out = String::from("prefix:");
+    let err = p.peek_to_string(&mut out).await.expect_err("io error");
+    assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+    assert_eq!(out, "prefix:h");
+  });
+}
+
+#[test]
+fn peek_retries_interrupted_from_inner_async() {
+  // AsyncPeek trait contract: poll_peek must not surface Interrupted.
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(
+      b"hello".to_vec(),
+      vec![Action::Interrupted, Action::ReadFromInner],
+    );
+    let mut p = AsyncPeekable::new(r);
+    let mut b = [0u8; 5];
+    let n = p.peek(&mut b).await.unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&b, b"hello");
+  });
+}
+
+#[test]
+fn peek_converts_wouldblock_to_pending_no_buffer_async() {
+  // AsyncPeek contract: WouldBlock must become Pending. Verified with
+  // a manual poll since await would retry until ready.
+  use std::future::Future;
+  let r = FlakyReader::new(b"hello".to_vec(), vec![Action::WouldBlock]);
+  let mut p = AsyncPeekable::new(r);
+  let waker = futures::task::noop_waker();
+  let mut cx = Context::from_waker(&waker);
+  let mut out = [0u8; 5];
+  let mut fut = Box::pin(p.peek(&mut out));
+  match fut.as_mut().poll(&mut cx) {
+    Poll::Pending => {} // expected — WouldBlock converted
+    other => panic!("unexpected: {:?}", other),
+  }
+}
+
+#[test]
+fn peek_converts_wouldblock_to_partial_with_buffer_async() {
+  // With an existing peek buffer, WouldBlock from the top-up returns
+  // a partial peek containing the buffered bytes rather than erroring.
+  use std::future::Future;
+  futures::executor::block_on(async {
+    let r = FlakyReader::new(
+      b"hello".to_vec(),
+      vec![Action::ReadFromInner, Action::WouldBlock],
+    );
+    let mut p = AsyncPeekable::new(r);
+    let mut b = [0u8; 2];
+    p.peek(&mut b).await.unwrap();
+    assert_eq!(&b, b"he");
+
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut out = [0u8; 5];
+    let mut fut = Box::pin(p.peek(&mut out));
+    match fut.as_mut().poll(&mut cx) {
+      Poll::Ready(Ok(n)) => {
+        assert_eq!(n, 2);
+        assert_eq!(&out[..2], b"he");
+      }
+      other => panic!("unexpected: {:?}", other),
+    }
   });
 }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -390,13 +390,27 @@ fn read_when_request_equal_to_buffer() {
 
 #[test]
 fn read_when_request_greater_than_buffer_error() {
+  // Peek 2 bytes into the peek buffer, then read 5 — the inner errors
+  // on the top-up. Updated behavior: the 2 buffered bytes are
+  // delivered (Read contract forbids Err after writing bytes), peek
+  // buffer is cleared, and the inner error surfaces on the next
+  // read() which delegates directly to the inner reader.
   let r = FlakyReader::new(
     b"hello".to_vec(),
-    vec![None, Some(io::Error::new(ErrorKind::Other, "boom"))],
+    vec![
+      None,
+      Some(io::Error::new(ErrorKind::Other, "boom")),
+      Some(io::Error::new(ErrorKind::Other, "boom")),
+    ],
   );
   let mut p = r.peekable();
   p.peek(&mut [0u8; 2]).unwrap();
+
   let mut out = [0u8; 5];
+  let n = p.read(&mut out).unwrap();
+  assert_eq!(n, 2);
+  assert_eq!(&out[..2], b"he");
+
   let err = p.read(&mut out).unwrap_err();
   assert_eq!(err.kind(), ErrorKind::Other);
 }
@@ -846,4 +860,93 @@ fn peek_to_string_returns_invalid_data_for_clean_invalid_utf8() {
   let err = p.peek_to_string(&mut out).expect_err("must fail");
   assert_eq!(err.kind(), ErrorKind::InvalidData);
   assert_eq!(out, "prefix:");
+}
+
+#[test]
+fn peek_to_end_retries_on_interrupted() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![
+      None,
+      Some(io::Error::new(ErrorKind::Interrupted, "x")),
+      None,
+    ],
+  );
+  let mut p = r.peekable();
+  let mut out = Vec::new();
+  let n = p.peek_to_end(&mut out).unwrap();
+  assert_eq!(n, 5);
+  assert_eq!(out, b"hello");
+}
+
+#[test]
+fn peek_to_string_retries_on_interrupted() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![
+      None,
+      Some(io::Error::new(ErrorKind::Interrupted, "x")),
+      None,
+    ],
+  );
+  let mut p = r.peekable();
+  let mut out = String::new();
+  let n = p.peek_to_string(&mut out).unwrap();
+  assert_eq!(n, 5);
+  assert_eq!(out, "hello");
+}
+
+#[test]
+fn peek_to_string_buffer_resize_fails_preserves_partial_utf8() {
+  // First read succeeds with 2 bytes ("he"), second resize fails
+  // because cap = 2 and next resize targets 2 + READ_CHUNK.
+  // With all valid-UTF-8 consumed, caller's String keeps "he".
+  let reader = Cursor::new(b"hello".to_vec());
+  let mut p = reader.peekable_with_capacity_and_buffer::<BoundedBuffer<2>>(2);
+  let mut scratch = [0u8; 2];
+  assert_eq!(p.peek(&mut scratch).unwrap(), 2);
+
+  let mut out = String::from("prefix:");
+  let err = p.peek_to_string(&mut out).expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+  assert_eq!(out, "prefix:he");
+}
+
+// ---- Adaptive growth: small-cap buffer must succeed when data fits --
+
+#[test]
+fn peek_to_end_succeeds_with_small_cap_when_data_fits() {
+  // Cap 100, stream 10 bytes. Before the adaptive fix this failed
+  // with OutOfMemory because resize(0+1024) > cap.
+  let reader = Cursor::new(b"0123456789".to_vec());
+  let mut p = reader.peekable_with_buffer::<BoundedBuffer<100>>();
+  let mut out = Vec::new();
+  let n = p.peek_to_end(&mut out).unwrap();
+  assert_eq!(n, 10);
+  assert_eq!(out, b"0123456789");
+}
+
+#[test]
+fn peek_to_string_succeeds_with_small_cap_when_data_fits() {
+  let reader = Cursor::new(b"hello".to_vec());
+  let mut p = reader.peekable_with_buffer::<BoundedBuffer<100>>();
+  let mut out = String::new();
+  let n = p.peek_to_string(&mut out).unwrap();
+  assert_eq!(n, 5);
+  assert_eq!(out, "hello");
+}
+
+// ---- peek_to_string: preserve valid-UTF-8 prefix when tail is mid-codepoint
+
+#[test]
+fn peek_to_string_preserves_valid_prefix_before_incomplete_utf8_on_io_error() {
+  // Reader produces "h" + [0xE2, 0x82] (first 2 bytes of 3-byte €)
+  // then errors. valid_up_to() = 1, so "h" is preserved, the
+  // incomplete multi-byte tail is dropped from the caller's String.
+  let reader = ErroringReader::new(vec![b'h', 0xE2, 0x82], 3, ErrorKind::ConnectionReset);
+  let mut p = reader.peekable();
+  let mut out = String::from("prefix:");
+  let err = p.peek_to_string(&mut out).expect_err("io error");
+  assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+  assert_eq!(out, "prefix:h");
 }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -647,3 +647,197 @@ fn peek_to_string_with_non_empty_destination_keeps_peek_buffer_in_sync() {
   p.read_to_string(&mut rest).unwrap();
   assert_eq!(rest, "abcdef");
 }
+
+// ------------------------------------------------------------------
+// Regression tests for:
+//   Finding 1: peek_to_string must preserve partial valid-UTF-8
+//              in the caller's String on ordinary I/O errors.
+//   Finding 2: a fallible Buffer must not leave the inner reader
+//              advanced past what the peek buffer can replay.
+// ------------------------------------------------------------------
+
+use peekable::buffer::Buffer;
+
+// Buffer whose resize/extend_from_slice fails once CAP bytes would
+// be exceeded. CAP is a const generic because Peekable constructors
+// call Buffer::new() with no runtime argument.
+#[derive(Debug, Default)]
+struct BoundedBuffer<const CAP: usize> {
+  inner: Vec<u8>,
+}
+
+impl<const CAP: usize> AsRef<[u8]> for BoundedBuffer<CAP> {
+  fn as_ref(&self) -> &[u8] {
+    &self.inner
+  }
+}
+
+impl<const CAP: usize> Buffer for BoundedBuffer<CAP> {
+  fn new() -> Self {
+    Self { inner: Vec::new() }
+  }
+  fn with_capacity(_: usize) -> Self {
+    Self { inner: Vec::new() }
+  }
+  fn consume(&mut self, rng: std::ops::RangeTo<usize>) {
+    self.inner.drain(rng);
+  }
+  fn clear(&mut self) {
+    self.inner.clear();
+  }
+  fn resize(&mut self, len: usize) -> io::Result<()> {
+    if len > CAP {
+      return Err(io::Error::new(io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+    }
+    self.inner.resize(len, 0);
+    Ok(())
+  }
+  fn truncate(&mut self, len: usize) {
+    self.inner.truncate(len);
+  }
+  fn extend_from_slice(&mut self, other: &[u8]) -> io::Result<()> {
+    if self.inner.len() + other.len() > CAP {
+      return Err(io::Error::new(io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+    }
+    self.inner.extend_from_slice(other);
+    Ok(())
+  }
+  fn as_slice(&self) -> &[u8] {
+    &self.inner
+  }
+  fn as_mut_slice(&mut self) -> &mut [u8] {
+    &mut self.inner
+  }
+  fn len(&self) -> usize {
+    self.inner.len()
+  }
+  fn is_empty(&self) -> bool {
+    self.inner.is_empty()
+  }
+  fn capacity(&self) -> usize {
+    CAP
+  }
+}
+
+// Reader that serves a fixed payload up to `error_after` bytes, then
+// returns a custom io::Error on subsequent calls.
+struct ErroringReader {
+  data: Cursor<Vec<u8>>,
+  error_after: usize,
+  served: usize,
+  kind: ErrorKind,
+}
+
+impl ErroringReader {
+  fn new(data: Vec<u8>, error_after: usize, kind: ErrorKind) -> Self {
+    Self {
+      data: Cursor::new(data),
+      error_after,
+      served: 0,
+      kind,
+    }
+  }
+}
+
+impl Read for ErroringReader {
+  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    if self.served >= self.error_after {
+      return Err(io::Error::new(self.kind, "synthetic"));
+    }
+    let cap = (self.error_after - self.served).min(buf.len());
+    let n = self.data.read(&mut buf[..cap])?;
+    self.served += n;
+    Ok(n)
+  }
+}
+
+#[test]
+fn peek_does_not_advance_reader_when_buffer_extend_fails() {
+  let reader = Cursor::new(vec![1u8, 2, 3, 4]);
+  let mut p = reader.peekable_with_buffer::<BoundedBuffer<0>>();
+  let mut buf = [0u8; 2];
+  let err = p.peek(&mut buf).expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+
+  let (_, reader) = p.get_mut();
+  let mut out = Vec::new();
+  reader.read_to_end(&mut out).unwrap();
+  assert_eq!(out, [1, 2, 3, 4]);
+}
+
+#[test]
+fn peek_exact_does_not_advance_reader_when_buffer_extend_fails() {
+  let reader = Cursor::new(vec![1u8, 2, 3, 4]);
+  let mut p = reader.peekable_with_buffer::<BoundedBuffer<0>>();
+  let mut buf = [0u8; 4];
+  let err = p.peek_exact(&mut buf).expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+
+  let (peek_slice, reader) = p.get_mut();
+  let have = peek_slice.len();
+  let mut out = Vec::new();
+  reader.read_to_end(&mut out).unwrap();
+  assert_eq!(have + out.len(), 4);
+}
+
+#[test]
+fn peek_to_end_preserves_partial_data_on_io_error() {
+  let reader = ErroringReader::new(b"hello".to_vec(), 3, ErrorKind::ConnectionReset);
+  let mut p = reader.peekable();
+  let mut out = Vec::new();
+  let err = p.peek_to_end(&mut out).expect_err("io error expected");
+  assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+  assert_eq!(out, b"hel");
+}
+
+#[test]
+fn peek_to_end_does_not_desync_on_buffer_error() {
+  // Seed 2 bytes into the peek buffer, then let peek_to_end try to
+  // grow the buffer past cap.
+  let reader = Cursor::new(b"abcdef".to_vec());
+  let mut p = reader.peekable_with_buffer::<BoundedBuffer<2>>();
+  let mut scratch = [0u8; 2];
+  assert_eq!(p.peek(&mut scratch).unwrap(), 2);
+
+  let mut out = Vec::new();
+  let err = p.peek_to_end(&mut out).expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+
+  let (peek_slice, reader) = p.get_mut();
+  let have = peek_slice.len();
+  let mut tail = Vec::new();
+  reader.read_to_end(&mut tail).unwrap();
+  assert_eq!(have + tail.len(), 6);
+}
+
+#[test]
+fn peek_to_string_preserves_partial_valid_utf8_on_io_error() {
+  let reader = ErroringReader::new(b"hello".to_vec(), 3, ErrorKind::ConnectionReset);
+  let mut p = reader.peekable();
+  let mut out = String::new();
+  let err = p.peek_to_string(&mut out).expect_err("io error expected");
+  assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+  assert_eq!(out, "hel");
+}
+
+#[test]
+fn peek_to_string_leaves_buf_unchanged_when_partial_bytes_are_invalid_utf8() {
+  // First two bytes of a 3-byte UTF-8 codepoint (0xE2 0x82 0xAC = €),
+  // then error. Accumulated bytes are not valid UTF-8 → buf unchanged.
+  let reader = ErroringReader::new(vec![0xE2, 0x82, 0xAC], 2, ErrorKind::ConnectionReset);
+  let mut p = reader.peekable();
+  let mut out = String::from("prefix:");
+  let err = p.peek_to_string(&mut out).expect_err("io error expected");
+  assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+  assert_eq!(out, "prefix:");
+}
+
+#[test]
+fn peek_to_string_returns_invalid_data_for_clean_invalid_utf8() {
+  let reader = Cursor::new(vec![0xFF, 0xFE]);
+  let mut p = reader.peekable();
+  let mut out = String::from("prefix:");
+  let err = p.peek_to_string(&mut out).expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::InvalidData);
+  assert_eq!(out, "prefix:");
+}

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -687,7 +687,10 @@ impl<const CAP: usize> Buffer for BoundedBuffer<CAP> {
   }
   fn resize(&mut self, len: usize) -> io::Result<()> {
     if len > CAP {
-      return Err(io::Error::new(io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+      return Err(io::Error::new(
+        io::ErrorKind::OutOfMemory,
+        "BoundedBuffer cap",
+      ));
     }
     self.inner.resize(len, 0);
     Ok(())
@@ -697,7 +700,10 @@ impl<const CAP: usize> Buffer for BoundedBuffer<CAP> {
   }
   fn extend_from_slice(&mut self, other: &[u8]) -> io::Result<()> {
     if self.inner.len() + other.len() > CAP {
-      return Err(io::Error::new(io::ErrorKind::OutOfMemory, "BoundedBuffer cap"));
+      return Err(io::Error::new(
+        io::ErrorKind::OutOfMemory,
+        "BoundedBuffer cap",
+      ));
     }
     self.inner.extend_from_slice(other);
     Ok(())

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -656,3 +656,203 @@ async fn peek_to_end_keeps_partial_data_on_error() {
   assert!(out.starts_with(b"seed"));
   assert!(out.len() > 4); // "seed" + at least the peek prefix
 }
+
+// ------------------------------------------------------------------
+// Regression tests for:
+//   Finding 1: peek_to_string must preserve partial valid-UTF-8 in
+//              the caller's String on ordinary I/O errors.
+//   Finding 2: a fallible Buffer must not leave the inner reader
+//              advanced past what the peek buffer can replay.
+// ------------------------------------------------------------------
+
+use peekable::buffer::Buffer;
+
+#[derive(Debug, Default)]
+struct BoundedBuffer<const CAP: usize> {
+  inner: Vec<u8>,
+}
+
+impl<const CAP: usize> AsRef<[u8]> for BoundedBuffer<CAP> {
+  fn as_ref(&self) -> &[u8] {
+    &self.inner
+  }
+}
+
+impl<const CAP: usize> Buffer for BoundedBuffer<CAP> {
+  fn new() -> Self {
+    Self { inner: Vec::new() }
+  }
+  fn with_capacity(_: usize) -> Self {
+    Self { inner: Vec::new() }
+  }
+  fn consume(&mut self, rng: std::ops::RangeTo<usize>) {
+    self.inner.drain(rng);
+  }
+  fn clear(&mut self) {
+    self.inner.clear();
+  }
+  fn resize(&mut self, len: usize) -> io::Result<()> {
+    if len > CAP {
+      return Err(io::Error::new(
+        io::ErrorKind::OutOfMemory,
+        "BoundedBuffer cap",
+      ));
+    }
+    self.inner.resize(len, 0);
+    Ok(())
+  }
+  fn truncate(&mut self, len: usize) {
+    self.inner.truncate(len);
+  }
+  fn extend_from_slice(&mut self, other: &[u8]) -> io::Result<()> {
+    if self.inner.len() + other.len() > CAP {
+      return Err(io::Error::new(
+        io::ErrorKind::OutOfMemory,
+        "BoundedBuffer cap",
+      ));
+    }
+    self.inner.extend_from_slice(other);
+    Ok(())
+  }
+  fn as_slice(&self) -> &[u8] {
+    &self.inner
+  }
+  fn as_mut_slice(&mut self) -> &mut [u8] {
+    &mut self.inner
+  }
+  fn len(&self) -> usize {
+    self.inner.len()
+  }
+  fn is_empty(&self) -> bool {
+    self.inner.is_empty()
+  }
+  fn capacity(&self) -> usize {
+    CAP
+  }
+}
+
+struct AsyncErroringReader {
+  data: Cursor<Vec<u8>>,
+  error_after: usize,
+  served: usize,
+  kind: ErrorKind,
+}
+
+impl AsyncErroringReader {
+  fn new(data: Vec<u8>, error_after: usize, kind: ErrorKind) -> Self {
+    Self {
+      data: Cursor::new(data),
+      error_after,
+      served: 0,
+      kind,
+    }
+  }
+}
+
+impl AsyncRead for AsyncErroringReader {
+  fn poll_read(
+    self: Pin<&mut Self>,
+    _cx: &mut Context<'_>,
+    buf: &mut ReadBuf<'_>,
+  ) -> Poll<io::Result<()>> {
+    let me = self.get_mut();
+    if me.served >= me.error_after {
+      return Poll::Ready(Err(io::Error::new(me.kind, "synthetic")));
+    }
+    let room = (me.error_after - me.served).min(buf.remaining());
+    if room == 0 {
+      return Poll::Ready(Ok(()));
+    }
+    let start = me.data.position() as usize;
+    let end = (start + room).min(me.data.get_ref().len());
+    let len = end - start;
+    let slice = me.data.get_ref()[start..end].to_vec();
+    buf.put_slice(&slice);
+    me.data.set_position(end as u64);
+    me.served += len;
+    Poll::Ready(Ok(()))
+  }
+}
+
+#[tokio::test]
+async fn tokio_peek_does_not_advance_reader_when_buffer_extend_fails() {
+  let reader = Cursor::new(vec![1u8, 2, 3, 4]);
+  let mut p: AsyncPeekable<_, BoundedBuffer<0>> = reader.peekable_with_buffer();
+  let mut buf = [0u8; 2];
+  let err = p.peek(&mut buf).await.expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+  let (_, reader) = p.get_mut();
+  let mut out = Vec::new();
+  reader.read_to_end(&mut out).await.unwrap();
+  assert_eq!(out, [1, 2, 3, 4]);
+}
+
+#[tokio::test]
+async fn tokio_peek_exact_does_not_advance_reader_when_buffer_extend_fails() {
+  let reader = Cursor::new(vec![1u8, 2, 3, 4]);
+  let mut p: AsyncPeekable<_, BoundedBuffer<0>> = reader.peekable_with_buffer();
+  let mut buf = [0u8; 4];
+  let err = p.peek_exact(&mut buf).await.expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+  let (peek_slice, reader) = p.get_mut();
+  let have = peek_slice.len();
+  let mut out = Vec::new();
+  reader.read_to_end(&mut out).await.unwrap();
+  assert_eq!(have + out.len(), 4);
+}
+
+#[tokio::test]
+async fn tokio_peek_to_end_preserves_partial_data_on_io_error() {
+  let reader = AsyncErroringReader::new(b"hello".to_vec(), 3, ErrorKind::ConnectionReset);
+  let mut p = reader.peekable();
+  let mut out = Vec::new();
+  let err = p.peek_to_end(&mut out).await.expect_err("io error");
+  assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+  assert_eq!(out, b"hel");
+}
+
+#[tokio::test]
+async fn tokio_peek_to_end_does_not_desync_on_buffer_error() {
+  let reader = Cursor::new(b"abcdef".to_vec());
+  let mut p: AsyncPeekable<_, BoundedBuffer<2>> = reader.peekable_with_buffer();
+  let mut scratch = [0u8; 2];
+  assert_eq!(p.peek(&mut scratch).await.unwrap(), 2);
+  let mut out = Vec::new();
+  let err = p.peek_to_end(&mut out).await.expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+  let (peek_slice, reader) = p.get_mut();
+  let have = peek_slice.len();
+  let mut tail = Vec::new();
+  reader.read_to_end(&mut tail).await.unwrap();
+  assert_eq!(have + tail.len(), 6);
+}
+
+#[tokio::test]
+async fn tokio_peek_to_string_preserves_partial_valid_utf8_on_io_error() {
+  let reader = AsyncErroringReader::new(b"hello".to_vec(), 3, ErrorKind::ConnectionReset);
+  let mut p = reader.peekable();
+  let mut out = String::new();
+  let err = p.peek_to_string(&mut out).await.expect_err("io error");
+  assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+  assert_eq!(out, "hel");
+}
+
+#[tokio::test]
+async fn tokio_peek_to_string_leaves_buf_unchanged_when_partial_bytes_are_invalid_utf8() {
+  let reader = AsyncErroringReader::new(vec![0xE2, 0x82, 0xAC], 2, ErrorKind::ConnectionReset);
+  let mut p = reader.peekable();
+  let mut out = String::from("prefix:");
+  let err = p.peek_to_string(&mut out).await.expect_err("io error");
+  assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+  assert_eq!(out, "prefix:");
+}
+
+#[tokio::test]
+async fn tokio_peek_to_string_returns_invalid_data_for_clean_invalid_utf8() {
+  let reader = Cursor::new(vec![0xFF, 0xFE]);
+  let mut p = reader.peekable();
+  let mut out = String::from("prefix:");
+  let err = p.peek_to_string(&mut out).await.expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::InvalidData);
+  assert_eq!(out, "prefix:");
+}

--- a/tests/tokio_io.rs
+++ b/tests/tokio_io.rs
@@ -29,6 +29,7 @@ use peekable::tokio::{AsyncPeek, AsyncPeekExt, AsyncPeekable};
 enum Action {
   Pending, // return Pending without registering a wake (test will explicit-wake)
   Interrupted,
+  WouldBlock,
   OtherErr,
   ReadFromInner, // read normally
 }
@@ -67,6 +68,7 @@ impl AsyncRead for FlakyReader {
         Poll::Pending
       }
       Action::Interrupted => Poll::Ready(Err(io::Error::new(ErrorKind::Interrupted, "x"))),
+      Action::WouldBlock => Poll::Ready(Err(io::Error::new(ErrorKind::WouldBlock, "wb"))),
       Action::OtherErr => Poll::Ready(Err(io::Error::new(ErrorKind::Other, "boom"))),
       Action::ReadFromInner => {
         let inner = std::pin::Pin::new(&mut self.inner);
@@ -173,17 +175,20 @@ async fn bug2_poll_read_on_pending_does_not_duplicate() {
 }
 
 // ------------------------------------------------------------------
-// Bug 3 regression: error during a read with non-empty peek buffer
-// rolls back filled() instead of corrupting bytes via inner_mut().
+// poll_read with non-empty peek buffer + inner error: the AsyncRead
+// contract forbids returning Err after writing bytes, so the buffered
+// bytes are delivered to the caller's ReadBuf and the inner error
+// surfaces on a subsequent poll_read once the peek buffer is empty.
 // ------------------------------------------------------------------
 
 #[tokio::test]
-async fn bug3_read_error_rolls_back_filled() {
+async fn read_delivers_buffered_bytes_then_surfaces_inner_err() {
   let r = FlakyReader::new(
     b"hello".to_vec(),
     vec![
       Action::ReadFromInner, // initial fill of 3 bytes
-      Action::OtherErr,      // read attempt errors
+      Action::OtherErr,      // top-up errors
+      Action::OtherErr,      // next direct read also errors
     ],
   );
   let mut p = AsyncPeekable::from(r);
@@ -192,10 +197,22 @@ async fn bug3_read_error_rolls_back_filled() {
   p.peek(&mut b).await.unwrap();
   assert_eq!(&b, b"hel");
 
-  // Read 5 — should hit error, and after the fix our caller's buf is
-  // unchanged from the rollback.
+  // First poll_read(5): we have 3 buffered bytes, inner errors on
+  // top-up. Expect Ok(()) with 3 bytes filled from the peek buffer.
   let waker = futures::task::noop_waker();
   let mut cx = Context::from_waker(&waker);
+  let mut out = [0u8; 5];
+  let mut buf = ReadBuf::new(&mut out);
+  let pinned = Pin::new(&mut p);
+  match AsyncRead::poll_read(pinned, &mut cx, &mut buf) {
+    Poll::Ready(Ok(())) => {
+      assert_eq!(buf.filled(), b"hel");
+    }
+    other => panic!("unexpected: {:?}", other),
+  }
+
+  // Second poll_read: peek buffer is now empty, delegates to inner,
+  // which returns Other. Caller sees the error.
   let mut out = [0u8; 5];
   let mut buf = ReadBuf::new(&mut out);
   let pinned = Pin::new(&mut p);
@@ -203,12 +220,6 @@ async fn bug3_read_error_rolls_back_filled() {
     Poll::Ready(Err(e)) => assert_eq!(e.kind(), ErrorKind::Other),
     other => panic!("unexpected: {:?}", other),
   }
-  assert_eq!(
-    buf.filled().len(),
-    0,
-    "filled not rolled back: {:?}",
-    buf.filled()
-  );
 }
 
 // ------------------------------------------------------------------
@@ -855,4 +866,201 @@ async fn tokio_peek_to_string_returns_invalid_data_for_clean_invalid_utf8() {
   let err = p.peek_to_string(&mut out).await.expect_err("must fail");
   assert_eq!(err.kind(), ErrorKind::InvalidData);
   assert_eq!(out, "prefix:");
+}
+
+// ---- Coverage for Interrupted / Pending / Err paths -----------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_exact_retries_on_interrupted() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![Action::Interrupted, Action::ReadFromInner],
+  );
+  let mut p = AsyncPeekable::from(r);
+  let mut b = [0u8; 5];
+  p.peek_exact(&mut b).await.unwrap();
+  assert_eq!(&b, b"hello");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_exact_propagates_error() {
+  let r = FlakyReader::new(b"hello".to_vec(), vec![Action::OtherErr]);
+  let mut p = AsyncPeekable::from(r);
+  let mut b = [0u8; 5];
+  let err = p.peek_exact(&mut b).await.unwrap_err();
+  assert_eq!(err.kind(), ErrorKind::Other);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_exact_survives_pending_boundary() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![Action::Pending, Action::ReadFromInner],
+  );
+  let mut p = AsyncPeekable::from(r);
+  let mut b = [0u8; 5];
+  p.peek_exact(&mut b).await.unwrap();
+  assert_eq!(&b, b"hello");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_to_end_retries_on_interrupted() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![
+      Action::ReadFromInner,
+      Action::Interrupted,
+      Action::ReadFromInner,
+    ],
+  );
+  let mut p = AsyncPeekable::from(r);
+  let mut out = Vec::new();
+  let n = p.peek_to_end(&mut out).await.unwrap();
+  assert_eq!(out, b"hello");
+  assert_eq!(n, 5);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_to_end_survives_pending() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![
+      Action::ReadFromInner,
+      Action::Pending,
+      Action::ReadFromInner,
+    ],
+  );
+  let mut p = AsyncPeekable::from(r);
+  let mut out = Vec::new();
+  let n = p.peek_to_end(&mut out).await.unwrap();
+  assert_eq!(out, b"hello");
+  assert_eq!(n, 5);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_to_string_retries_on_interrupted() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![
+      Action::ReadFromInner,
+      Action::Interrupted,
+      Action::ReadFromInner,
+    ],
+  );
+  let mut p = AsyncPeekable::from(r);
+  let mut out = String::new();
+  let n = p.peek_to_string(&mut out).await.unwrap();
+  assert_eq!(out, "hello");
+  assert_eq!(n, 5);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_to_string_survives_pending() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![
+      Action::ReadFromInner,
+      Action::Pending,
+      Action::ReadFromInner,
+    ],
+  );
+  let mut p = AsyncPeekable::from(r);
+  let mut out = String::new();
+  let n = p.peek_to_string(&mut out).await.unwrap();
+  assert_eq!(out, "hello");
+  assert_eq!(n, 5);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_to_string_buffer_resize_fails_preserves_partial_utf8() {
+  let reader = Cursor::new(b"hello".to_vec());
+  let mut p: AsyncPeekable<_, BoundedBuffer<2>> = reader.peekable_with_capacity_and_buffer(2);
+  let mut scratch = [0u8; 2];
+  assert_eq!(p.peek(&mut scratch).await.unwrap(), 2);
+  let mut out = String::from("prefix:");
+  let err = p.peek_to_string(&mut out).await.expect_err("must fail");
+  assert_eq!(err.kind(), ErrorKind::OutOfMemory);
+  assert_eq!(out, "prefix:he");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_to_end_succeeds_with_small_cap_when_data_fits() {
+  let reader = Cursor::new(b"0123456789".to_vec());
+  let mut p: AsyncPeekable<_, BoundedBuffer<100>> = reader.peekable_with_buffer();
+  let mut out = Vec::new();
+  let n = p.peek_to_end(&mut out).await.unwrap();
+  assert_eq!(n, 10);
+  assert_eq!(out, b"0123456789");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_to_string_succeeds_with_small_cap_when_data_fits() {
+  let reader = Cursor::new(b"hello".to_vec());
+  let mut p: AsyncPeekable<_, BoundedBuffer<100>> = reader.peekable_with_buffer();
+  let mut out = String::new();
+  let n = p.peek_to_string(&mut out).await.unwrap();
+  assert_eq!(n, 5);
+  assert_eq!(out, "hello");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_to_string_preserves_valid_prefix_before_incomplete_utf8_on_io_error() {
+  let reader = AsyncErroringReader::new(vec![b'h', 0xE2, 0x82], 3, ErrorKind::ConnectionReset);
+  let mut p = reader.peekable();
+  let mut out = String::from("prefix:");
+  let err = p.peek_to_string(&mut out).await.expect_err("io error");
+  assert_eq!(err.kind(), ErrorKind::ConnectionReset);
+  assert_eq!(out, "prefix:h");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_retries_interrupted_from_inner() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![Action::Interrupted, Action::ReadFromInner],
+  );
+  let mut p = AsyncPeekable::from(r);
+  let mut b = [0u8; 5];
+  let n = p.peek(&mut b).await.unwrap();
+  assert_eq!(n, 5);
+  assert_eq!(&b, b"hello");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_converts_wouldblock_to_pending_no_buffer() {
+  use std::future::Future;
+  let r = FlakyReader::new(b"hello".to_vec(), vec![Action::WouldBlock]);
+  let mut p = AsyncPeekable::from(r);
+  let waker = futures::task::noop_waker();
+  let mut cx = Context::from_waker(&waker);
+  let mut out = [0u8; 5];
+  let mut fut = Box::pin(p.peek(&mut out));
+  match fut.as_mut().poll(&mut cx) {
+    Poll::Pending => {} // expected
+    other => panic!("unexpected: {:?}", other),
+  }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_peek_converts_wouldblock_to_partial_with_buffer() {
+  let r = FlakyReader::new(
+    b"hello".to_vec(),
+    vec![Action::ReadFromInner, Action::WouldBlock],
+  );
+  let mut p = AsyncPeekable::from(r);
+  let mut b = [0u8; 2];
+  p.peek(&mut b).await.unwrap();
+  assert_eq!(&b, b"he");
+
+  let waker = futures::task::noop_waker();
+  let mut cx = Context::from_waker(&waker);
+  let mut out = [0u8; 5];
+  let mut buf = ReadBuf::new(&mut out);
+  let pinned = Pin::new(&mut p);
+  match pinned.poll_peek(&mut cx, &mut buf) {
+    Poll::Ready(Ok(())) => {
+      assert_eq!(buf.filled(), b"he");
+    }
+    other => panic!("unexpected: {:?}", other),
+  }
 }


### PR DESCRIPTION
## Summary

Addresses a batch of correctness issues across `Peekable` / `AsyncPeekable`
(sync, `future`, `tokio`). Every fix is accompanied by regression tests.

### Two original findings
- **`peek_to_string` preserves partial valid UTF-8 on ordinary I/O error**
  (was returning `Err` with `buf` unchanged, hiding partial text the reader
  already produced). `Utf8Error::valid_up_to()` is used so even a
  "valid text + incomplete multi-byte tail" stream preserves the valid
  prefix.
- **Fallible `Buffer` implementations can no longer desync the inner
  reader from the peek buffer.** Every peek path now grows the peek
  buffer first and has the reader write directly into the resized tail,
  truncating on both success and error.

### Follow-ups from Copilot review
- **Adaptive buffer growth** for `peek_to_end` / `peek_to_string`: on
  `resize(old_len + READ_CHUNK)` failure, halves the growth down to 1
  byte so small-capacity bounded buffers can still serve streams that
  fit.
- **`AsyncRead::poll_read` contract**: was returning `Err` after
  copying `buffer_len` bytes into the caller's slice — violated the
  "no bytes written on Err" invariant and could duplicate on retry.
  Now clears the peek buffer and returns `Ok(buffer_len)`; the inner
  error surfaces on the next call (which delegates directly to the
  inner reader).
- **`AsyncPeek::poll_peek` contract**: the trait docs explicitly
  forbid returning `Interrupted` or `WouldBlock`. Both branches now
  retry on `Interrupted` and convert `WouldBlock` to `Pending`
  (or to a partial `Ready` when the peek buffer already satisfies
  the caller).
- **`(Err(io), Err(utf8))` in `peek_to_string`**: the "longest valid
  UTF-8 prefix" claim in the doc was not honored when a valid prefix
  was followed by an incomplete multi-byte tail — fixed via
  `valid_up_to()`.

### Internal
- Removed the per-future `StagingBuf` helper; the peek buffer itself
  is now the staging area.
- Flattened `match x.cmp(&y)` → `if/else` chains in the sync / futures /
  tokio `poll_read` / `poll_peek` dispatch so tarpaulin credits the
  branch bodies.

## Test plan

- [x] \`cargo test --all-features\` — 222 tests pass (34 new regression
      tests across sync / futures / tokio)
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo tarpaulin --all-features --run-types lib --run-types tests --run-types doctests --workspace\` — **95.42%** line coverage (up from 89.87% pre-PR)

## Compatibility

- Semver: patch bump (\`0.6.0\` → \`0.6.1\`). API unchanged; only
  internal semantics of error/partial-read paths tightened.
- \`peek_to_string\` on I/O error is now slightly more permissive than
  \`std::io::Read::read_to_string\` (preserves longest valid-UTF-8
  prefix even when followed by an incomplete multi-byte sequence) —
  documented in the function's \`# Errors\` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)